### PR TITLE
Use the login resource to authenticate

### DIFF
--- a/abiquo/src/main/java/org/jclouds/abiquo/functions/auth/GetTokenFromApi.java
+++ b/abiquo/src/main/java/org/jclouds/abiquo/functions/auth/GetTokenFromApi.java
@@ -77,7 +77,7 @@ public class GetTokenFromApi implements Function<Credentials, String> {
 
       HttpResponse response = http.invoke(HttpRequest.builder() //
             .method("GET") //
-            .endpoint(URI.create(provider.getEndpoint())) //
+            .endpoint(URI.create(provider.getEndpoint() + "/login")) //
             .addHeader(AUTHORIZATION, basic(input.identity, input.credential)) //
             .build());
 


### PR DESCRIPTION
Some providers do not expose the "root" api endpoint, so it should be better not used to get the token. The login resource can be used instead.
