### PR TITLE
JCLOUDS-367: GCE nodes n>1 ignoring inboundPort

### DIFF
--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineService.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineService.java
@@ -61,7 +61,10 @@ import org.jclouds.domain.Location;
 import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
 import org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions;
 import org.jclouds.googlecomputeengine.config.UserProject;
+import org.jclouds.googlecomputeengine.domain.Firewall;
+import org.jclouds.googlecomputeengine.domain.Network;
 import org.jclouds.googlecomputeengine.domain.Operation;
+import org.jclouds.googlecomputeengine.features.FirewallApi;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.scriptbuilder.functions.InitAdminAccess;
 
@@ -69,6 +72,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
 /**
@@ -146,21 +150,34 @@ public class GoogleComputeEngineService extends BaseComputeService {
    }
 
 
-   protected void cleanUpNetworksAndFirewallsForGroup(String groupName) {
+   protected void cleanUpNetworksAndFirewallsForGroup(final String groupName) {
       String resourceName = namingConvention.create().sharedNameForGroup(groupName);
-      AtomicReference<Operation> operation = new AtomicReference<Operation>(api.getFirewallApiForProject(project.get())
-              .delete(resourceName));
+      final Network network = api.getNetworkApiForProject(project.get()).get(resourceName);
+      FirewallApi firewallApi = api.getFirewallApiForProject(project.get());
+      Predicate<Firewall> firewallBelongsToNetwork = new Predicate<Firewall>() {
+         @Override
+         public boolean apply(Firewall input) {
+            return input != null && input.getNetwork().equals(network.getSelfLink());
+         }
+      };
 
-      retry(operationDonePredicate, operationCompleteCheckTimeout, operationCompleteCheckInterval,
-              MILLISECONDS).apply(operation);
-
-      if (operation.get().getHttpError().isPresent()) {
-         HttpResponse response = operation.get().getHttpError().get();
-         logger.warn("delete orphaned firewall failed. Http Error Code: " + response.getStatusCode() +
-                 " HttpError: " + response.getMessage());
+      Set<AtomicReference<Operation>> operations = Sets.newHashSet();
+      for (Firewall firewall : firewallApi.list().concat().filter(firewallBelongsToNetwork)) {
+         operations.add(new AtomicReference<Operation>(firewallApi.delete(firewall.getName())));
       }
 
-      operation = new AtomicReference<Operation>(api.getNetworkApiForProject(project.get()).delete(resourceName));
+      for (AtomicReference<Operation> operation : operations) {
+         retry(operationDonePredicate, operationCompleteCheckTimeout, operationCompleteCheckInterval,
+                 MILLISECONDS).apply(operation);
+
+         if (operation.get().getHttpError().isPresent()) {
+            HttpResponse response = operation.get().getHttpError().get();
+            logger.warn("delete orphaned firewall %s failed. Http Error Code: %d HttpError: %s",
+                    operation.get().getTargetId(), response.getStatusCode(), response.getMessage());
+         }
+      }
+
+      AtomicReference<Operation> operation = new AtomicReference<Operation>(api.getNetworkApiForProject(project.get()).delete(resourceName));
 
       retry(operationDonePredicate, operationCompleteCheckTimeout, operationCompleteCheckInterval,
               MILLISECONDS).apply(operation);

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/config/GoogleComputeEngineServiceContextModule.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.google.inject.Scopes;
 import org.jclouds.collect.Memoized;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceAdapter;
@@ -43,6 +44,7 @@ import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
 import org.jclouds.googlecomputeengine.compute.GoogleComputeEngineService;
 import org.jclouds.googlecomputeengine.compute.GoogleComputeEngineServiceAdapter;
 import org.jclouds.googlecomputeengine.compute.functions.BuildInstanceMetadata;
+import org.jclouds.googlecomputeengine.compute.functions.FirewallTagNamingConvention;
 import org.jclouds.googlecomputeengine.compute.functions.GoogleComputeEngineImageToImage;
 import org.jclouds.googlecomputeengine.compute.functions.InstanceInZoneToNodeMetadata;
 import org.jclouds.googlecomputeengine.compute.functions.MachineTypeInZoneToHardware;
@@ -119,6 +121,7 @@ public class GoogleComputeEngineServiceContextModule
 
       install(new LocationsFromComputeServiceAdapterModule<InstanceInZone, MachineTypeInZone, Image, Zone>() {});
 
+      bind(FirewallTagNamingConvention.Factory.class).in(Scopes.SINGLETON);
    }
 
    @Provides

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallTagNamingConvention.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/FirewallTagNamingConvention.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.googlecomputeengine.compute.functions;
+
+import com.google.common.base.Predicate;
+import org.jclouds.compute.functions.GroupNamingConvention;
+
+import javax.inject.Inject;
+
+/**
+ * The convention for naming instance tags that firewall rules recognise.
+ * 
+ * @author richardcloudsoft
+ */
+public class FirewallTagNamingConvention {
+
+   public static class Factory {
+
+      private final GroupNamingConvention.Factory namingConvention;
+
+      @Inject
+      public Factory(GroupNamingConvention.Factory namingConvention) {
+         this.namingConvention = namingConvention;
+      }
+
+      public FirewallTagNamingConvention get(String groupName) {
+         return new FirewallTagNamingConvention(namingConvention.create().sharedNameForGroup(groupName));
+      }
+   }
+
+   private final String sharedResourceName;
+
+   public FirewallTagNamingConvention(String sharedResourceName) {
+      this.sharedResourceName = sharedResourceName;
+   }
+
+   public String name(int port) {
+      return String.format("%s-port-%s", sharedResourceName, port);
+   }
+
+   public Predicate<? super String> isFirewallTag() {
+      return new Predicate<String>() {
+         @Override
+         public boolean apply(String input) {
+            return input != null && input.startsWith(sharedResourceName + "-port-");
+         }
+      };
+   }
+
+}

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadata.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/InstanceInZoneToNodeMetadata.java
@@ -36,7 +36,9 @@ import org.jclouds.googlecomputeengine.domain.InstanceInZone;
 import org.jclouds.googlecomputeengine.domain.SlashEncodedIds;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -51,18 +53,21 @@ public class InstanceInZoneToNodeMetadata implements Function<InstanceInZone, No
    private final Supplier<Map<URI, ? extends Image>> images;
    private final Supplier<Map<URI, ? extends Hardware>> hardwares;
    private final Supplier<Map<URI, ? extends Location>> locations;
+   private final FirewallTagNamingConvention.Factory firewallTagNamingConvention;
 
    @Inject
    public InstanceInZoneToNodeMetadata(Map<Instance.Status, NodeMetadata.Status> toPortableNodeStatus,
                                  GroupNamingConvention.Factory namingConvention,
                                  @Memoized Supplier<Map<URI, ? extends Image>> images,
                                  @Memoized Supplier<Map<URI, ? extends Hardware>> hardwares,
-                                 @Memoized Supplier<Map<URI, ? extends Location>> locations) {
+                                 @Memoized Supplier<Map<URI, ? extends Location>> locations,
+                                 FirewallTagNamingConvention.Factory firewallTagNamingConvention) {
       this.toPortableNodeStatus = toPortableNodeStatus;
       this.nodeNamingConvention = namingConvention.createWithoutPrefix();
       this.images = images;
       this.hardwares = hardwares;
       this.locations = locations;
+      this.firewallTagNamingConvention = checkNotNull(firewallTagNamingConvention, "firewallTagNamingConvention");
    }
 
    @Override
@@ -71,6 +76,10 @@ public class InstanceInZoneToNodeMetadata implements Function<InstanceInZone, No
       Map<URI, ? extends Image> imagesMap = images.get();
       Image image = checkNotNull(imagesMap.get(checkNotNull(input.getImage(), "image")),
               "no image for %s. images: %s", input.getImage(), imagesMap.values());
+
+      String group = nodeNamingConvention.groupInUniqueNameOrNull(input.getName());
+      FluentIterable<String> tags = FluentIterable.from(input.getTags().getItems())
+              .filter(Predicates.not(firewallTagNamingConvention.get(group).isFirewallTag()));
 
       return new NodeMetadataBuilder()
               .id(SlashEncodedIds.fromTwoIds(checkNotNull(locations.get().get(input.getZone()), "location for %s", input.getZone()).getId(),
@@ -84,10 +93,10 @@ public class InstanceInZoneToNodeMetadata implements Function<InstanceInZone, No
                       input.getMachineType().toString()))
               .operatingSystem(image.getOperatingSystem())
               .status(toPortableNodeStatus.get(input.getStatus()))
-              .tags(input.getTags().getItems())
+              .tags(tags)
               .uri(input.getSelfLink())
               .userMetadata(input.getMetadata())
-              .group(nodeNamingConvention.groupInUniqueNameOrNull(input.getName()))
+              .group(group)
               .privateAddresses(collectPrivateAddresses(input))
               .publicAddresses(collectPublicAddresses(input))
               .build();

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/strategy/CreateNodesWithGroupEncodedIntoNameThenAddToSet.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/strategy/CreateNodesWithGroupEncodedIntoNameThenAddToSet.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.google.common.collect.Sets;
 import org.jclouds.Constants;
 import org.jclouds.compute.config.CustomizationResponse;
 import org.jclouds.compute.domain.NodeMetadata;
@@ -40,11 +41,13 @@ import org.jclouds.compute.strategy.CreateNodeWithGroupEncodedIntoName;
 import org.jclouds.compute.strategy.CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap;
 import org.jclouds.compute.strategy.ListNodesStrategy;
 import org.jclouds.googlecomputeengine.GoogleComputeEngineApi;
+import org.jclouds.googlecomputeengine.compute.functions.FirewallTagNamingConvention;
 import org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions;
 import org.jclouds.googlecomputeengine.config.UserProject;
 import org.jclouds.googlecomputeengine.domain.Firewall;
 import org.jclouds.googlecomputeengine.domain.Network;
 import org.jclouds.googlecomputeengine.domain.Operation;
+import org.jclouds.googlecomputeengine.features.FirewallApi;
 import org.jclouds.googlecomputeengine.options.FirewallOptions;
 
 import com.google.common.base.Predicate;
@@ -68,6 +71,7 @@ public class CreateNodesWithGroupEncodedIntoNameThenAddToSet extends
    private final Predicate<AtomicReference<Operation>> operationDonePredicate;
    private final long operationCompleteCheckInterval;
    private final long operationCompleteCheckTimeout;
+   private final FirewallTagNamingConvention.Factory firewallTagNamingConvention;
 
    @Inject
    protected CreateNodesWithGroupEncodedIntoNameThenAddToSet(
@@ -82,7 +86,8 @@ public class CreateNodesWithGroupEncodedIntoNameThenAddToSet extends
            @UserProject Supplier<String> userProject,
            @Named("global") Predicate<AtomicReference<Operation>> operationDonePredicate,
            @Named(OPERATION_COMPLETE_INTERVAL) Long operationCompleteCheckInterval,
-           @Named(OPERATION_COMPLETE_TIMEOUT) Long operationCompleteCheckTimeout) {
+           @Named(OPERATION_COMPLETE_TIMEOUT) Long operationCompleteCheckTimeout,
+           FirewallTagNamingConvention.Factory firewallTagNamingConvention) {
       super(addNodeWithGroupStrategy, listNodesStrategy, namingConvention, userExecutor,
               customizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapFactory);
 
@@ -93,6 +98,7 @@ public class CreateNodesWithGroupEncodedIntoNameThenAddToSet extends
       this.operationCompleteCheckTimeout = checkNotNull(operationCompleteCheckTimeout,
               "operation completed check timeout");
       this.operationDonePredicate = operationDonePredicate;
+      this.firewallTagNamingConvention = checkNotNull(firewallTagNamingConvention, "firewallTagNamingConvention");
    }
 
    @Override
@@ -110,7 +116,7 @@ public class CreateNodesWithGroupEncodedIntoNameThenAddToSet extends
 
       // get or create the network and create a firewall with the users configuration
       Network network = getOrCreateNetwork(templateOptions, sharedResourceName);
-      getOrCreateFirewall(templateOptions, network, sharedResourceName);
+      getOrCreateFirewalls(templateOptions, network, firewallTagNamingConvention.get(group));
       templateOptions.network(network.getSelfLink());
 
       return super.execute(group, count, mutableTemplate, goodNodes, badNodes, customizationResponses);
@@ -145,51 +151,45 @@ public class CreateNodesWithGroupEncodedIntoNameThenAddToSet extends
    }
 
    /**
-    * Tries to find if a firewall already exists for this group, if not it creates one.
-    *
-    * @see org.jclouds.googlecomputeengine.features.FirewallAsyncApi#patch(String, org.jclouds.googlecomputeengine.options.FirewallOptions)
+    * Ensures that a firewall exists for every inbound port that the instance requests.
+    * <p>
+    * For each port, there must be a firewall with a name following the {@link FirewallTagNamingConvention},
+    * with a target tag also following the {@link FirewallTagNamingConvention}, which opens the requested port
+    * for all sources on both TCP and UDP protocols.
     */
-   private void getOrCreateFirewall(GoogleComputeEngineTemplateOptions templateOptions, Network network,
-                                    String sharedResourceName) {
+   private void getOrCreateFirewalls(GoogleComputeEngineTemplateOptions templateOptions, Network network,
+                                     FirewallTagNamingConvention naming) {
 
-      Firewall firewall = api.getFirewallApiForProject(userProject.get()).get(sharedResourceName);
+      String projectName = userProject.get();
+      FirewallApi firewallApi = api.getFirewallApiForProject(projectName);
+      Set<AtomicReference<Operation>> operations = Sets.newHashSet();
 
-      if (firewall != null) {
-         return;
-      }
-
-      ImmutableSet.Builder<Firewall.Rule> rules = ImmutableSet.builder();
-
-      Firewall.Rule.Builder tcpRule = Firewall.Rule.builder();
-      tcpRule.IPProtocol(Firewall.Rule.IPProtocol.TCP);
-      Firewall.Rule.Builder udpRule = Firewall.Rule.builder();
-      udpRule.IPProtocol(Firewall.Rule.IPProtocol.UDP);
       for (Integer port : templateOptions.getInboundPorts()) {
-         tcpRule.addPort(port);
-         udpRule.addPort(port);
+         String name = naming.name(port);
+         Firewall firewall = firewallApi.get(name);
+         if (firewall == null) {
+            ImmutableSet<Firewall.Rule> rules = ImmutableSet.of(Firewall.Rule.permitTcpRule(port), Firewall.Rule.permitUdpRule(port));
+            FirewallOptions firewallOptions = new FirewallOptions()
+                    .name(name)
+                    .network(network.getSelfLink())
+                    .allowedRules(rules)
+                    .sourceTags(templateOptions.getTags())
+                    .sourceRanges(of(DEFAULT_INTERNAL_NETWORK_RANGE, EXTERIOR_RANGE))
+                    .targetTags(ImmutableSet.of(name));
+            AtomicReference<Operation> operation = new AtomicReference<Operation>(firewallApi.createInNetwork(
+                    firewallOptions.getName(),
+                    network.getSelfLink(),
+                    firewallOptions));
+            operations.add(operation);
+         }
       }
-      rules.add(tcpRule.build());
-      rules.add(udpRule.build());
 
+      for (AtomicReference<Operation> operation : operations) {
+         retry(operationDonePredicate, operationCompleteCheckTimeout, operationCompleteCheckInterval,
+                 MILLISECONDS).apply(operation);
 
-      FirewallOptions options = new FirewallOptions()
-              .name(sharedResourceName)
-              .network(network.getSelfLink())
-              .sourceTags(templateOptions.getTags())
-              .allowedRules(rules.build())
-              .sourceRanges(of(DEFAULT_INTERNAL_NETWORK_RANGE, EXTERIOR_RANGE));
-
-      AtomicReference<Operation> operation = new AtomicReference<Operation>(api.getFirewallApiForProject(userProject
-              .get()).createInNetwork(
-              sharedResourceName,
-              network.getSelfLink(),
-              options));
-
-      retry(operationDonePredicate, operationCompleteCheckTimeout, operationCompleteCheckInterval,
-              MILLISECONDS).apply(operation);
-
-      checkState(!operation.get().getHttpError().isPresent(), "Could not create firewall, operation failed" + operation);
+         checkState(!operation.get().getHttpError().isPresent(),"Could not create firewall, operation failed" + operation);
+      }
    }
-
 
 }

--- a/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Firewall.java
+++ b/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/domain/Firewall.java
@@ -266,6 +266,12 @@ public final class Firewall extends Resource {
       private final IPProtocol ipProtocol;
       private final RangeSet<Integer> ports;
 
+      /* Some handy shortcuts */
+      public static Rule permitTcpRule(Integer start, Integer end) { return Rule.builder().IPProtocol(Firewall.Rule.IPProtocol.TCP).addPortRange(start, end).build(); }
+      public static Rule permitTcpRule(Integer port) { return Rule.builder().IPProtocol(Firewall.Rule.IPProtocol.TCP).addPort(port).build(); }
+      public static Rule permitUdpRule(Integer start, Integer end) { return Rule.builder().IPProtocol(Firewall.Rule.IPProtocol.UDP).addPortRange(start, end).build(); }
+      public static Rule permitUdpRule(Integer port) { return Rule.builder().IPProtocol(Firewall.Rule.IPProtocol.UDP).addPort(port).build(); }
+
       @ConstructorProperties({
               "IPProtocol", "ports"
       })

--- a/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
+++ b/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/GoogleComputeEngineServiceExpectTest.java
@@ -269,6 +269,26 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .addHeader("Accept", "application/json")
               .addHeader("Authorization", "Bearer " + TOKEN).build();
 
+      HttpRequest getNetworkRequest = HttpRequest.builder()
+              .method("GET")
+              .endpoint("https://www.googleapis" +
+                      ".com/compute/v1beta15/projects/myproject/global/networks/jclouds-test-delete")
+              .addHeader("Accept", "application/json")
+              .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpResponse getNetworkResponse = HttpResponse.builder().statusCode(200)
+              .payload(staticPayloadFromResource("/GoogleComputeEngineServiceExpectTest/network_get.json")).build();
+   
+      HttpRequest listFirewallsRequest = HttpRequest.builder()
+              .method("GET")
+              .endpoint("https://www.googleapis" +
+                      ".com/compute/v1beta15/projects/myproject/global/firewalls")
+              .addHeader("Accept", "application/json")
+              .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpResponse listFirewallsResponse = HttpResponse.builder().statusCode(200)
+              .payload(staticPayloadFromResource("/GoogleComputeEngineServiceExpectTest/firewall_list.json")).build();
+      
       HttpRequest deleteNetworkReqquest = HttpRequest.builder()
               .method("DELETE")
               .endpoint("https://www.googleapis" +
@@ -289,6 +309,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(GET_ZONE_OPERATION_REQUEST)
               .add(getInstanceRequestForInstance("test-delete-networks"))
               .add(LIST_INSTANCES_REQUEST)
+              .add(getNetworkRequest)
+              .add(listFirewallsRequest)
               .add(deleteFirewallRequest)
               .add(GET_GLOBAL_OPERATION_REQUEST)
               .add(deleteNetworkReqquest)
@@ -313,6 +335,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(getListInstancesResponseForSingleInstanceAndNetworkAndStatus("test-delete-networks",
                       "test-network", Instance
                       .Status.TERMINATED.name()))
+              .add(getNetworkResponse)
+              .add(listFirewallsResponse)
               .add(SUCESSFULL_OPERATION_RESPONSE)
               .add(GET_GLOBAL_OPERATION_RESPONSE)
               .add(SUCESSFULL_OPERATION_RESPONSE)
@@ -363,6 +387,38 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
       HttpResponse getInstanceResponse = HttpResponse.builder().statusCode(200)
               .payload(payloadFromStringWithContentType(payload, "application/json")).build();
 
+      HttpRequest getFirewallRequest = HttpRequest
+                 .builder()
+                 .method("GET")
+                 .endpoint("https://www.googleapis" +
+                         ".com/compute/v1beta15/projects/myproject/global/firewalls/jclouds-test-port-22")
+                 .addHeader("Accept", "application/json")
+                 .addHeader("Authorization", "Bearer " + TOKEN).build();
+
+      HttpRequest insertFirewallRequest = HttpRequest
+                 .builder()
+                 .method("POST")
+                 .endpoint("https://www.googleapis.com/compute/v1beta15/projects/myproject/global/firewalls")
+                 .addHeader("Accept", "application/json")
+                 .addHeader("Authorization", "Bearer " + TOKEN)
+                 .payload(payloadFromStringWithContentType("{\"name\":\"jclouds-test-port-22\",\"network\":\"https://www.googleapis" +
+                         ".com/compute/v1beta15/projects/myproject/global/networks/jclouds-test\"," +
+                         "\"sourceRanges\":[\"10.0.0.0/8\",\"0.0.0.0/0\"],\"targetTags\":[\"jclouds-test-port-22\"],\"allowed\":[{\"IPProtocol\":\"tcp\"," +
+                         "\"ports\":[\"22\"]}," +
+                         "{\"IPProtocol\":\"udp\",\"ports\":[\"22\"]}]}",
+                         MediaType.APPLICATION_JSON))
+                 .build();
+
+      HttpRequest setTagsRequest = HttpRequest
+                 .builder()
+                 .method("POST")
+                 .endpoint("https://www.googleapis.com/compute/v1beta15/projects/myproject/zones/us-central1-a/instances/test-1/setTags")
+                 .addHeader("Accept", "application/json")
+                 .addHeader("Authorization", "Bearer " + TOKEN)
+                 .payload(payloadFromStringWithContentType("{\"items\":[\"jclouds-test-port-22\"],\"fingerprint\":\"abcd\"}",
+                         MediaType.APPLICATION_JSON))
+                 .build();
+      
       List<HttpRequest> orderedRequests = ImmutableList.<HttpRequest>builder()
               .add(requestForScopes(COMPUTE_READONLY_SCOPE))
               .add(GET_PROJECT_REQUEST)
@@ -376,8 +432,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(INSERT_NETWORK_REQUEST)
               .add(GET_GLOBAL_OPERATION_REQUEST)
               .add(GET_NETWORK_REQUEST)
-              .add(GET_FIREWALL_REQUEST)
-              .add(INSERT_FIREWALL_REQUEST)
+              .add(getFirewallRequest)
+              .add(insertFirewallRequest)
               .add(GET_GLOBAL_OPERATION_REQUEST)
               .add(LIST_INSTANCES_REQUEST)
               .add(LIST_PROJECT_IMAGES_REQUEST)
@@ -389,6 +445,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(SET_TAGS_REQUEST)
               .add(GET_ZONE_OPERATION_REQUEST)
               .add(getInstanceRequestForInstance("test-1"))
+              .add(setTagsRequest)
+              .add(setTagsRequest)
               .build();
 
       List<HttpResponse> orderedResponses = ImmutableList.<HttpResponse>builder()
@@ -417,6 +475,8 @@ public class GoogleComputeEngineServiceExpectTest extends BaseGoogleComputeEngin
               .add(SET_TAGS_RESPONSE)
               .add(GET_ZONE_OPERATION_RESPONSE)
               .add(getInstanceResponse)
+              .add(SUCESSFULL_OPERATION_RESPONSE)
+              .add(SUCESSFULL_OPERATION_RESPONSE)
               .build();
 
 

--- a/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/firewall_list.json
+++ b/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/firewall_list.json
@@ -1,0 +1,37 @@
+{
+   "kind": "compute#firewallList",
+   "id": "projects/google/firewalls",
+   "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/google/global/firewalls",
+   "items": [
+      {
+
+         "kind": "compute#firewall",
+         "id": "12862241031274216284",
+         "creationTimestamp": "2012-04-13T03:05:02.855",
+         "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/myproject/global/firewalls/jclouds-test-delete",
+         "name": "jclouds-test-delete",
+         "description": "Internal traffic from default allowed",
+         "network": "https://www.googleapis.com/compute/v1beta15/projects/myproject/global/networks/jclouds-test-delete",
+         "sourceRanges": [
+            "10.0.0.0/8"
+         ],
+         "allowed": [
+            {
+               "IPProtocol": "tcp",
+               "ports": [
+                  "1-65535"
+               ]
+            },
+            {
+               "IPProtocol": "udp",
+               "ports": [
+                  "1-65535"
+               ]
+            },
+            {
+               "IPProtocol": "icmp"
+            }
+         ]
+      }
+   ]
+}

--- a/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/network_get.json
+++ b/google-compute-engine/src/test/resources/GoogleComputeEngineServiceExpectTest/network_get.json
@@ -1,0 +1,10 @@
+{
+   "kind": "compute#network",
+   "id": "13024414170909937976",
+   "creationTimestamp": "2012-10-24T20:13:19.967",
+   "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/myproject/global/networks/jclouds-test-delete",
+   "name": "jclouds-test-delete",
+   "description": "Default network for the project",
+   "IPv4Range": "10.0.0.0/8",
+   "gatewayIPv4": "10.0.0.1"
+}


### PR DESCRIPTION
The inboundPort settings of the first node in the group dictated the firewall configuration. Subsequent nodes added to the group had their inboundPort settings ignored.

GCE firewalls specify their "target" (VM instances) by means of tags - if a targetTag on a firewall matches the tag on an instance, the firewall's rules are allowed for the instance. This commit applies a tag for each requested inboundPort to new instances. Then, a firewall is created for each tag (if one does not already exist) which has 'allow' rules for the port.
