### PR TITLE
CloudSigma2 API cleanup

### DIFF
--- a/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/CloudSigma2Api.java
+++ b/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/CloudSigma2Api.java
@@ -974,7 +974,7 @@ public interface CloudSigma2Api extends Closeable {
     * @param subscriptionRequest subscription request object
     * @return created subscription
     */
-   @Named("subscription:listSubscriptionsCalculator")
+   @Named("subscription:createSubscription")
    @POST
    @Path("/subscriptions/")
    @SelectJson("objects")

--- a/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/CloudSigma2ApiMetadata.java
+++ b/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/CloudSigma2ApiMetadata.java
@@ -16,20 +16,19 @@
  */
 package org.jclouds.cloudsigma2;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Module;
-import org.jclouds.apis.ApiMetadata;
-import org.jclouds.cloudsigma2.config.CloudSigma2HttpApiModule;
-import org.jclouds.cloudsigma2.config.CloudSigma2ParserModule;
-import org.jclouds.cloudsigma2.config.CloudSigma2Properties;
-import org.jclouds.compute.ComputeServiceContext;
-import org.jclouds.rest.internal.BaseHttpApiMetadata;
+import static org.jclouds.compute.config.ComputeServiceProperties.TEMPLATE;
 
 import java.net.URI;
 import java.util.Properties;
 
-import static org.jclouds.compute.config.ComputeServiceProperties.TEMPLATE;
-import static org.jclouds.reflect.Reflection2.typeToken;
+import org.jclouds.apis.ApiMetadata;
+import org.jclouds.cloudsigma2.config.CloudSigma2HttpApiModule;
+import org.jclouds.cloudsigma2.config.CloudSigma2ParserModule;
+import org.jclouds.cloudsigma2.config.CloudSigma2Properties;
+import org.jclouds.rest.internal.BaseHttpApiMetadata;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
 
 /**
  * Implementation of {@link BaseHttpApiMetadata} for the Cloud Sigma API
@@ -76,7 +75,8 @@ public class CloudSigma2ApiMetadata extends BaseHttpApiMetadata<CloudSigma2Api> 
                .version("2.0")
                .defaultEndpoint("https://zrh.cloudsigma.com/api/2.0")
                .defaultProperties(CloudSigma2ApiMetadata.defaultProperties())
-               .view(typeToken(ComputeServiceContext.class))
+               // Uncomment once the ComputeService is implemented 
+               //.view(typeToken(ComputeServiceContext.class))
                .defaultModules(ImmutableSet.<Class<? extends Module>>of(
                      CloudSigma2HttpApiModule.class,
                      CloudSigma2ParserModule.class));

--- a/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/handlers/CloudSigmaErrorHandler.java
+++ b/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/handlers/CloudSigmaErrorHandler.java
@@ -82,7 +82,12 @@ public class CloudSigmaErrorHandler implements HttpErrorHandler {
                break;
          }
       } finally {
-         Closeables.closeQuietly(response.getPayload());
+         try {
+            Closeables.close(response.getPayload(), true);
+          } catch (IOException e) {
+             // This code will never be reached
+             throw Throwables.propagate(e);
+          }
          command.setException(exception);
       }
    }

--- a/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/options/PaginationOptions.java
+++ b/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/options/PaginationOptions.java
@@ -49,10 +49,7 @@ public class PaginationOptions extends BaseHttpRequestOptions {
             offset = 0;
          }
 
-         PaginationOptions paginationOptions = new PaginationOptions(limit, offset, 0);
-         paginationOptions.queryParameters.put("limit", String.valueOf(limit));
-         paginationOptions.queryParameters.put("offset", String.valueOf(offset));
-         return paginationOptions;
+         return new PaginationOptions(limit, offset, 0);
       }
    }
 
@@ -68,6 +65,8 @@ public class PaginationOptions extends BaseHttpRequestOptions {
       this.limit = limit;
       this.offset = offset;
       this.totalCount = totalCount;
+      queryParameters.put("limit", String.valueOf(limit));
+      queryParameters.put("offset", String.valueOf(offset));
    }
 
    public int getTotalCount() {


### PR DESCRIPTION
Cleaned up the CloudSigma2 API:
- Removed the ComputeService view from the ApiMetadata (there is still no ComputeService implementation).
- Enabled the tag live tests, as they are now passing again.
- Fixed the editProfileInfo live test.

@Kentzo, @shevchenator: I've executed all live tests and all of them are passing again except the _testListSubscriptionsCalculator_ one. It was working a few days ago, but has started failing now. Are there any changes in the server side that can have caused this? (Anyway, fixing that live test should be done in a different PR, as it is unrelated to this one).

```
Caused by: org.jclouds.http.HttpResponseException: command: GET https://lvs.cloudsigma.com/api/2.0/subscriptioncalculator/ HTTP/1.1 failed with response: HTTP/1.1 405 METHOD NOT ALLOWED; content: []
at org.jclouds.cloudsigma2.handlers.CloudSigmaErrorHandler.handleError(CloudSigmaErrorHandler.java:51)
... 31 more
Caused by: org.jclouds.http.HttpResponseException: command: GET https://lvs.cloudsigma.com/api/2.0/subscriptioncalculator/ HTTP/1.1 failed with response: HTTP/1.1 405 METHOD NOT ALLOWED; content: []
at org.jclouds.cloudsigma2.handlers.CloudSigmaErrorHandler.handleError(CloudSigmaErrorHandler.java:51)
... 31 more
```
