### PR TITLE
Revert "[JCLOUDS-415] Upgrade to guava 16.0"

### DIFF
--- a/jclouds-management/management-blobstore/pom.xml
+++ b/jclouds-management/management-blobstore/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0</version>
+      <version>15.0</version>
     </dependency>
   </dependencies>
 

--- a/jclouds-management/management-compute/pom.xml
+++ b/jclouds-management/management-compute/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0</version>
+      <version>15.0</version>
     </dependency>
   </dependencies>
 

--- a/jclouds-management/management-core/pom.xml
+++ b/jclouds-management/management-core/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0</version>
+      <version>15.0</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/jclouds-representations/representations-codec/pom.xml
+++ b/jclouds-representations/representations-codec/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0</version>
+      <version>15.0</version>
     </dependency>
 
     <dependency>

--- a/jclouds-representations/representations-core/pom.xml
+++ b/jclouds-representations/representations-core/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0</version>
+      <version>15.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Not switching to a new Guava version outside major releases.

This reverts commit 6e9419f1c3e781c2f7c3eb49c8d179bf03c99f29.

See similar revert at https://github.com/jclouds/jclouds-karaf/commit/897bd89557b0847075f4fb38a4cb6aab2d5c0bb2
