### PR TITLE
Align management and representations with the upstream Guava version

### DIFF
--- a/jclouds-management/management-core/pom.xml
+++ b/jclouds-management/management-core/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0</version>
+      <version>16.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/jclouds-representations/representations-codec/pom.xml
+++ b/jclouds-representations/representations-codec/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0</version>
+      <version>16.0.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This is needed, otherwise some tests fail due to [JCLOUDS-427](https://issues.apache.org/jira/browse/JCLOUDS-427).
