### PR TITLE
JCLOUDS-543: hack to not barf on old images that are no longer listed in the api

### DIFF
--- a/digitalocean/src/main/java/org/jclouds/digitalocean/compute/functions/DropletToNodeMetadata.java
+++ b/digitalocean/src/main/java/org/jclouds/digitalocean/compute/functions/DropletToNodeMetadata.java
@@ -91,6 +91,9 @@ public class DropletToNodeMetadata implements Function<Droplet, NodeMetadata> {
       }));
 
       Image image = images.get().get(String.valueOf(input.getImageId()));
+      // If the results of the /images API call do not contain an image with this droplet's image_id,
+      // the call above will return null and we won't know anything about the droplet's image.
+      // In this case we do not populate the builder's imageId and operatingSystem properties.
       if (image != null) {
           builder.imageId(image.getId());
           builder.operatingSystem(image.getOperatingSystem());


### PR DESCRIPTION
preface -- I'm sure there is probably a better way to do this and I'm open to suggestions on changes.

the problem: some of the droplets in my account are long-running, and have image_ids that are no longer returned from DO's /images api call. So, when I'm trying to create a new droplet, it fails here with a NPE while iterating over the existing droplets (trying to find ones that might match the group name).
