### PR TITLE
Use AutoService for creation of Service Loader Metadata

### DIFF
--- a/cdmi/pom.xml
+++ b/cdmi/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/CDMIApiMetadata.java
+++ b/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/CDMIApiMetadata.java
@@ -19,12 +19,15 @@ package org.jclouds.snia.cdmi.v1;
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.apis.ApiMetadata;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 import org.jclouds.snia.cdmi.v1.config.CDMIHttpApiModule;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
+@AutoService(ApiMetadata.class)
 public class CDMIApiMetadata extends BaseHttpApiMetadata {
 
    @Override

--- a/cdmi/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/cdmi/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,1 +1,0 @@
-org.jclouds.snia.cdmi.v1.CDMIApiMetadata

--- a/cloudsigma2-hnl/pom.xml
+++ b/cloudsigma2-hnl/pom.xml
@@ -89,6 +89,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cloudsigma2-hnl/src/main/java/org/jclouds/cloudsigma2/CloudSigma2HonoluluProviderMetadata.java
+++ b/cloudsigma2-hnl/src/main/java/org/jclouds/cloudsigma2/CloudSigma2HonoluluProviderMetadata.java
@@ -22,9 +22,12 @@ import java.util.Properties;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of {@link org.jclouds.providers.internal.BaseProviderMetadata} for CloudSigma Honolulu.
+ * Implementation of {@link ProviderMetadata} for CloudSigma Honolulu.
  */
+@AutoService(ProviderMetadata.class)
 public class CloudSigma2HonoluluProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {

--- a/cloudsigma2-hnl/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/cloudsigma2-hnl/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.cloudsigma2.CloudSigma2HonoluluProviderMetadata

--- a/cloudsigma2-lvs/pom.xml
+++ b/cloudsigma2-lvs/pom.xml
@@ -89,6 +89,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cloudsigma2-lvs/src/main/java/org/jclouds/cloudsigma2/CloudSigma2LasVegasProviderMetadata.java
+++ b/cloudsigma2-lvs/src/main/java/org/jclouds/cloudsigma2/CloudSigma2LasVegasProviderMetadata.java
@@ -22,9 +22,12 @@ import java.util.Properties;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of {@link org.jclouds.providers.internal.BaseProviderMetadata} for CloudSigma Las Vegas.
+ * Implementation of {@link ProviderMetadata} for CloudSigma Las Vegas.
  */
+@AutoService(ProviderMetadata.class)
 public class CloudSigma2LasVegasProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {

--- a/cloudsigma2-lvs/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/cloudsigma2-lvs/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.cloudsigma2.CloudSigma2LasVegasProviderMetadata

--- a/cloudsigma2-sjc/pom.xml
+++ b/cloudsigma2-sjc/pom.xml
@@ -89,6 +89,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cloudsigma2-sjc/src/main/java/org/jclouds/cloudsigma2/CloudSigma2SanJoseProviderMetadata.java
+++ b/cloudsigma2-sjc/src/main/java/org/jclouds/cloudsigma2/CloudSigma2SanJoseProviderMetadata.java
@@ -22,9 +22,12 @@ import java.util.Properties;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of {@link org.jclouds.providers.internal.BaseProviderMetadata} for CloudSigma San Jose.
+ * Implementation of {@link ProviderMetadata} for CloudSigma San Jose.
  */
+@AutoService(ProviderMetadata.class)
 public class CloudSigma2SanJoseProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {

--- a/cloudsigma2-sjc/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/cloudsigma2-sjc/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.cloudsigma2.CloudSigma2SanJoseProviderMetadata

--- a/cloudsigma2-wdc/pom.xml
+++ b/cloudsigma2-wdc/pom.xml
@@ -89,6 +89,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cloudsigma2-wdc/src/main/java/org/jclouds/cloudsigma2/CloudSigma2WashingtonProviderMetadata.java
+++ b/cloudsigma2-wdc/src/main/java/org/jclouds/cloudsigma2/CloudSigma2WashingtonProviderMetadata.java
@@ -16,15 +16,18 @@
  */
 package org.jclouds.cloudsigma2;
 
-import org.jclouds.providers.ProviderMetadata;
-import org.jclouds.providers.internal.BaseProviderMetadata;
-
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of {@link org.jclouds.providers.internal.BaseProviderMetadata} for CloudSigma Washington DC.
+ * Implementation of {@link ProviderMetadata} for CloudSigma Washington DC.
  */
+@AutoService(ProviderMetadata.class)
 public class CloudSigma2WashingtonProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {

--- a/cloudsigma2-wdc/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/cloudsigma2-wdc/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.cloudsigma2.CloudSigma2WashingtonProviderMetadata

--- a/cloudsigma2-zrh/pom.xml
+++ b/cloudsigma2-zrh/pom.xml
@@ -89,6 +89,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cloudsigma2-zrh/src/main/java/org/jclouds/cloudsigma2/CloudSigma2ZurichProviderMetadata.java
+++ b/cloudsigma2-zrh/src/main/java/org/jclouds/cloudsigma2/CloudSigma2ZurichProviderMetadata.java
@@ -16,15 +16,18 @@
  */
 package org.jclouds.cloudsigma2;
 
-import org.jclouds.providers.ProviderMetadata;
-import org.jclouds.providers.internal.BaseProviderMetadata;
-
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of {@link org.jclouds.providers.internal.BaseProviderMetadata} for CloudSigma Zurich.
+ * Implementation of {@link ProviderMetadata} for CloudSigma Zurich.
  */
+@AutoService(ProviderMetadata.class)
 public class CloudSigma2ZurichProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {

--- a/cloudsigma2-zrh/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/cloudsigma2-zrh/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.cloudsigma2.CloudSigma2ZurichProviderMetadata

--- a/cloudsigma2/pom.xml
+++ b/cloudsigma2/pom.xml
@@ -81,6 +81,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>com.google.auto.service</groupId>
+          <artifactId>auto-service</artifactId>
+          <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/CloudSigma2ApiMetadata.java
+++ b/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/CloudSigma2ApiMetadata.java
@@ -31,12 +31,14 @@ import org.jclouds.cloudsigma2.config.CloudSigma2ParserModule;
 import org.jclouds.compute.ComputeServiceContext;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
 /**
- * Implementation of {@link BaseHttpApiMetadata} for the Cloud Sigma API
+ * Implementation of {@link ApiMetadata} for the Cloud Sigma API
  */
+@AutoService(ApiMetadata.class)
 public class CloudSigma2ApiMetadata extends BaseHttpApiMetadata<CloudSigma2Api> {
 
    @Override

--- a/cloudsigma2/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/cloudsigma2/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,1 +1,0 @@
-org.jclouds.cloudsigma2.CloudSigma2ApiMetadata

--- a/digitalocean/pom.xml
+++ b/digitalocean/pom.xml
@@ -87,6 +87,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/digitalocean/src/main/java/org/jclouds/digitalocean/DigitalOceanProviderMetadata.java
+++ b/digitalocean/src/main/java/org/jclouds/digitalocean/DigitalOceanProviderMetadata.java
@@ -22,9 +22,12 @@ import java.util.Properties;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
  * Implementation of {@link ProviderMetadata} for DigitalOcean.
  */
+@AutoService(ProviderMetadata.class)
 public class DigitalOceanProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {

--- a/digitalocean/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/digitalocean/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.digitalocean.DigitalOceanProviderMetadata

--- a/joyent-cloudapi/pom.xml
+++ b/joyent-cloudapi/pom.xml
@@ -84,6 +84,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/JoyentCloudApiMetadata.java
+++ b/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/JoyentCloudApiMetadata.java
@@ -21,6 +21,7 @@ import static org.jclouds.reflect.Reflection2.typeToken;
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.apis.ApiMetadata;
 import org.jclouds.compute.ComputeServiceContext;
 import org.jclouds.joyent.cloudapi.v6_5.compute.config.JoyentCloudComputeServiceContextModule;
 import org.jclouds.joyent.cloudapi.v6_5.config.DatacentersAreZonesModule;
@@ -28,9 +29,11 @@ import org.jclouds.joyent.cloudapi.v6_5.config.JoyentCloudHttpApiModule;
 import org.jclouds.joyent.cloudapi.v6_5.config.JoyentCloudProperties;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
+@AutoService(ApiMetadata.class)
 public class JoyentCloudApiMetadata extends BaseHttpApiMetadata {
 
    @Override
@@ -49,7 +52,7 @@ public class JoyentCloudApiMetadata extends BaseHttpApiMetadata {
    public static Properties defaultProperties() {
       Properties properties = BaseHttpApiMetadata.defaultProperties();
       // auth fail sometimes happens, as the rc.local script that injects the
-      // authorized key executes after ssh has started.  
+      // authorized key executes after ssh has started.
       properties.setProperty("jclouds.ssh.max-retries", "7");
       properties.setProperty("jclouds.ssh.retry-auth", "true");
       properties.setProperty(JoyentCloudProperties.AUTOGENERATE_KEYS, "true");

--- a/joyent-cloudapi/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/joyent-cloudapi/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,1 +1,0 @@
-org.jclouds.joyent.cloudapi.v6_5.JoyentCloudApiMetadata

--- a/joyentcloud/pom.xml
+++ b/joyentcloud/pom.xml
@@ -91,6 +91,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/joyentcloud/src/main/java/org/jclouds/joyent/joyentcloud/JoyentCloudProviderMetadata.java
+++ b/joyentcloud/src/main/java/org/jclouds/joyent/joyentcloud/JoyentCloudProviderMetadata.java
@@ -27,9 +27,12 @@ import org.jclouds.joyent.cloudapi.v6_5.JoyentCloudApiMetadata;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of {@link org.jclouds.types.ProviderMetadata} for SDC.
+ * Implementation of {@link ProviderMetadata} for SDC.
  */
+@AutoService(ProviderMetadata.class)
 public class JoyentCloudProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {

--- a/joyentcloud/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/joyentcloud/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.joyent.joyentcloud.JoyentCloudProviderMetadata


### PR DESCRIPTION
This PR updates the remaining APIs/Providers to use AutoService.