### PR TITLE
Split Auto dependencies

### DIFF
--- a/abiquo/pom.xml
+++ b/abiquo/pom.xml
@@ -57,6 +57,11 @@
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
       <scope>provided</scope>

--- a/azurecompute/pom.xml
+++ b/azurecompute/pom.xml
@@ -68,9 +68,13 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
-      <version>1.0-rc2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -59,6 +59,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
Splitting the auto-service and auto-value dependencies allows us to control individual versions of these libraries.