### PR TITLE
Properly set the name and distribution of the DigitalOcean images

### DIFF
--- a/digitalocean/src/main/java/org/jclouds/digitalocean/compute/functions/ImageToImage.java
+++ b/digitalocean/src/main/java/org/jclouds/digitalocean/compute/functions/ImageToImage.java
@@ -36,23 +36,24 @@ public class ImageToImage implements Function<Image, org.jclouds.compute.domain.
 
    @Override
    public org.jclouds.compute.domain.Image apply(final Image input) {
+      String description = input.getOs().getDistribution().getValue() + " " + input.getName();
       ImageBuilder builder = new ImageBuilder();
       // Private images don't have a slug
       builder.id(input.getSlug() != null ? input.getSlug() : String.valueOf(input.getId()));
       builder.providerId(String.valueOf(input.getId()));
       builder.name(input.getName());
-      builder.description(input.getName());
+      builder.description(description);
       builder.status(Status.AVAILABLE);
 
       OperatingSystem os = input.getOs();
 
-      builder.operatingSystem(builder() 
-            .name(input.getName()) 
-            .family(os.getDistribution().getOsFamily()) 
-            .description(input.getName()) 
-            .arch(os.getArch()) 
-            .version(os.getVersion()) 
-            .is64Bit(os.is64bit()) 
+      builder.operatingSystem(builder()
+            .name(os.getDistribution().getValue())
+            .family(os.getDistribution().getOsFamily())
+            .description(description)
+            .arch(os.getArch())
+            .version(os.getVersion())
+            .is64Bit(os.is64bit())
             .build());
 
       ImmutableMap.Builder<String, String> metadata = ImmutableMap.builder();

--- a/digitalocean/src/main/java/org/jclouds/digitalocean/compute/strategy/CreateKeyPairsThenCreateNodes.java
+++ b/digitalocean/src/main/java/org/jclouds/digitalocean/compute/strategy/CreateKeyPairsThenCreateNodes.java
@@ -16,7 +16,6 @@
  */
 package org.jclouds.digitalocean.compute.strategy;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.tryFind;
 
@@ -105,9 +104,9 @@ public class CreateKeyPairsThenCreateNodes extends CreateNodesWithGroupEncodedIn
 
       // If there is a script to run in the node, make sure a pivate key has been configured so jclouds will be able to
       // access the node
-      if (options.getRunScript() != null) {
-         checkArgument(!Strings.isNullOrEmpty(options.getLoginPrivateKey()),
-               "no private key configured for: %s; please use options.overrideLoginPrivateKey(rsa_private_text)", group);
+      if (options.getRunScript() != null && Strings.isNullOrEmpty(options.getLoginPrivateKey())) {
+         logger.warn(">> A runScript has been configured but no SSH key has been provided."
+               + " Authentication will delegate to the ssh-agent");
       }
 
       // If there is a key configured, then make sure there is a key pair for it

--- a/digitalocean/src/main/java/org/jclouds/digitalocean/domain/Distribution.java
+++ b/digitalocean/src/main/java/org/jclouds/digitalocean/domain/Distribution.java
@@ -30,12 +30,8 @@ import com.google.common.base.Predicate;
  * DigitalOcean image distributions.
  */
 public enum Distribution {
-   ARCHLINUX(OsFamily.ARCH, "Arch Linux"), 
-   CENTOS(OsFamily.CENTOS, "CentOS"), 
-   DEBIAN(OsFamily.DEBIAN, "Debian"), 
-   FEDORA(OsFamily.FEDORA, "Fedora"), 
-   UBUNTU(OsFamily.UBUNTU, "Ubuntu"), 
-   UNRECOGNIZED(OsFamily.UNRECOGNIZED, ""); 
+   ARCHLINUX(OsFamily.ARCH, "Arch Linux"), CENTOS(OsFamily.CENTOS, "CentOS"), DEBIAN(OsFamily.DEBIAN, "Debian"), FEDORA(
+         OsFamily.FEDORA, "Fedora"), UBUNTU(OsFamily.UBUNTU, "Ubuntu"), UNRECOGNIZED(OsFamily.UNRECOGNIZED, "");
 
    private static final List<Distribution> values = asList(Distribution.values());
 
@@ -49,6 +45,10 @@ public enum Distribution {
 
    public OsFamily getOsFamily() {
       return this.osFamily;
+   }
+
+   public String getValue() {
+      return value;
    }
 
    public static Distribution fromValue(String value) {

--- a/digitalocean/src/main/java/org/jclouds/digitalocean/domain/Image.java
+++ b/digitalocean/src/main/java/org/jclouds/digitalocean/domain/Image.java
@@ -19,8 +19,13 @@ package org.jclouds.digitalocean.domain;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.beans.ConstructorProperties;
+import java.util.List;
+
+import javax.inject.Named;
 
 import org.jclouds.javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * An Image.
@@ -31,14 +36,21 @@ public class Image {
    private final OperatingSystem os;
    private final boolean publicImage;
    private final String slug;
+   @Named("regions")
+   private final List<Integer> regionIds;
+   @Named("region_slugs")
+   private final List<String> regionSlugs;
 
-   @ConstructorProperties({ "id", "name", "distribution", "public", "slug" })
-   public Image(int id, String name, String distribution, boolean publicImage, @Nullable String slug) {
+   @ConstructorProperties({ "id", "name", "distribution", "public", "slug", "regions", "region_slugs" })
+   public Image(int id, String name, String distribution, boolean publicImage, @Nullable String slug,
+         List<Integer> regionIds, List<String> regionSlugs) {
       this.id = id;
       this.name = checkNotNull(name, "name");
       this.os = OperatingSystem.builder().from(name, checkNotNull(distribution, "distribution")).build();
       this.publicImage = publicImage;
       this.slug = slug;
+      this.regionIds = ImmutableList.copyOf(checkNotNull(regionIds, "regionIds"));
+      this.regionSlugs = ImmutableList.copyOf(checkNotNull(regionSlugs, "regionSlugs"));
    }
 
    public int getId() {
@@ -61,6 +73,14 @@ public class Image {
       return slug;
    }
 
+   public List<Integer> getRegionIds() {
+      return regionIds;
+   }
+
+   public List<String> getRegionSlugs() {
+      return regionSlugs;
+   }
+
    @Override
    public int hashCode() {
       final int prime = 31;
@@ -70,6 +90,8 @@ public class Image {
       result = prime * result + (os == null ? 0 : os.hashCode());
       result = prime * result + (publicImage ? 1231 : 1237);
       result = prime * result + (slug == null ? 0 : slug.hashCode());
+      result = prime * result + (regionIds == null ? 0 : regionIds.hashCode());
+      result = prime * result + (regionSlugs == null ? 0 : regionSlugs.hashCode());
       return result;
    }
 
@@ -112,13 +134,27 @@ public class Image {
       } else if (!slug.equals(other.slug)) {
          return false;
       }
+      if (regionIds == null) {
+         if (other.regionIds != null) {
+            return false;
+         }
+      } else if (!regionIds.equals(other.regionIds)) {
+         return false;
+      }
+      if (regionSlugs == null) {
+         if (other.regionSlugs != null) {
+            return false;
+         }
+      } else if (!regionSlugs.equals(other.regionSlugs)) {
+         return false;
+      }
       return true;
    }
 
    @Override
    public String toString() {
       return "Image [id=" + id + ", name=" + name + ", os=" + os + ", publicImage=" + publicImage + ", slug=" + slug
-            + "]";
+            + ", regionIds=" + regionIds + ", regionSlugs=" + regionSlugs + "]";
    }
 
 }

--- a/digitalocean/src/main/java/org/jclouds/digitalocean/domain/OperatingSystem.java
+++ b/digitalocean/src/main/java/org/jclouds/digitalocean/domain/OperatingSystem.java
@@ -26,14 +26,13 @@ import java.util.regex.Pattern;
 /**
  * The operating system of an image.
  * <p>
- * This class parses the <code>name</code> string (e.g. "Ubuntu 12.10 x64") of the images and properly sets each field
- * to the right value.
+ * This class parses the <code>name</code> string (e.g. "12.10 x64") of the images and properly sets each field to the
+ * right value.
  */
 public class OperatingSystem {
 
-   // Parse something like "Ubuntu 12.10 x64"
-   private static final Pattern VERSION_PATTERN = compile("\\s(\\d+(?:\\.?\\d+)?)");
-   private static final Pattern ARCH_PATTERN = compile("x\\d{2}");
+   // Parse something like "12.10 x64" or "Ubuntu 12.10.1 x64" and matches the version and architecture
+   private static final Pattern VERSION_PATTERN = compile("(?:[a-zA-Z\\s]*\\s+)?(\\d+(?:\\.?\\d+)*)?(?:\\s*(x\\d{2}))?.*");
    private static final String IS_64_BIT = "x64";
 
    private final Distribution distribution;
@@ -77,13 +76,13 @@ public class OperatingSystem {
       }
 
       public OperatingSystem build() {
-         return new OperatingSystem(distribution, match(VERSION_PATTERN, name, 1), match(ARCH_PATTERN, name, 0));
+         return new OperatingSystem(distribution, match(VERSION_PATTERN, name, 1), match(VERSION_PATTERN, name, 2));
       }
    }
 
    private static String match(final Pattern pattern, final String input, int group) {
       Matcher m = pattern.matcher(input);
-      return m.find() ? nullToEmpty(m.group(group)) : "";
+      return m.matches() ? nullToEmpty(m.group(group)) : "";
    }
 
    @Override

--- a/digitalocean/src/test/java/org/jclouds/digitalocean/compute/functions/ImageToImageTest.java
+++ b/digitalocean/src/test/java/org/jclouds/digitalocean/compute/functions/ImageToImageTest.java
@@ -25,6 +25,7 @@ import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.digitalocean.domain.Image;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -35,18 +36,23 @@ public class ImageToImageTest {
 
    @Test
    public void testConvertImage() {
-      Image image = new Image(1, "Ubuntu 14.04 x64", "Ubuntu 14.04 x64", true, "ubuntu-1404-x86");
+      Image image = new Image(1, "14.04 x64", "Ubuntu", true, "ubuntu-1404-x86", ImmutableList.<Integer> of(),
+            ImmutableList.<String> of());
       org.jclouds.compute.domain.Image expected = new ImageBuilder()
             .id("ubuntu-1404-x86")
             .providerId("1")
-            .name("Ubuntu 14.04 x64")
+            .name("14.04 x64")
+            .description("Ubuntu 14.04 x64")
             .status(AVAILABLE)
             .operatingSystem(
-                  OperatingSystem.builder().name("Ubuntu 14.04 x64").description("Ubuntu 14.04 x64")
-                        .family(OsFamily.UBUNTU).version("14.04").arch("x64").is64Bit(true).build())
+                  OperatingSystem.builder().name("Ubuntu").description("Ubuntu 14.04 x64").family(OsFamily.UBUNTU)
+                        .version("14.04").arch("x64").is64Bit(true).build())
             .userMetadata(ImmutableMap.of("publicImage", "true")).build();
 
-      ImageToImage function = new ImageToImage();
-      assertEquals(function.apply(image), expected);
+      org.jclouds.compute.domain.Image result = new ImageToImage().apply(image);
+      assertEquals(result, expected);
+      assertEquals(result.getDescription(), expected.getDescription());
+      assertEquals(result.getOperatingSystem(), expected.getOperatingSystem());
+      assertEquals(result.getStatus(), expected.getStatus());
    }
 }

--- a/digitalocean/src/test/java/org/jclouds/digitalocean/domain/OperatingSystemTest.java
+++ b/digitalocean/src/test/java/org/jclouds/digitalocean/domain/OperatingSystemTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 public class OperatingSystemTest {
 
    public void testParseStandard64bit() {
-      OperatingSystem os = OperatingSystem.builder().from("Ubuntu 12.10 x64", "Ubuntu").build();
+      OperatingSystem os = OperatingSystem.builder().from("12.10 x64", "Ubuntu").build();
 
       assertEquals(os.getDistribution(), Distribution.UBUNTU);
       assertEquals(os.getVersion(), "12.10");
@@ -37,22 +37,40 @@ public class OperatingSystemTest {
       assertTrue(os.is64bit());
    }
 
+   public void testLongVersionStandard64bit() {
+      OperatingSystem os = OperatingSystem.builder().from("12.10.1 x64", "Ubuntu").build();
+
+      assertEquals(os.getDistribution(), Distribution.UBUNTU);
+      assertEquals(os.getVersion(), "12.10.1");
+      assertEquals(os.getArch(), "x64");
+      assertTrue(os.is64bit());
+   }
+
+   public void testParseStandard64bitWithPrefix() {
+      OperatingSystem os = OperatingSystem.builder().from("Arch Linux 12.10 x64 Desktop", "Arch Linux").build();
+
+      assertEquals(os.getDistribution(), Distribution.ARCHLINUX);
+      assertEquals(os.getVersion(), "12.10");
+      assertEquals(os.getArch(), "x64");
+      assertTrue(os.is64bit());
+   }
+
    public void testParseStandard() {
-      OperatingSystem os = OperatingSystem.builder().from("Ubuntu 12.10 x32", "Ubuntu").build();
+      OperatingSystem os = OperatingSystem.builder().from("12.10 x32", "Ubuntu").build();
 
       assertEquals(os.getDistribution(), Distribution.UBUNTU);
       assertEquals(os.getVersion(), "12.10");
       assertEquals(os.getArch(), "x32");
       assertFalse(os.is64bit());
 
-      os = OperatingSystem.builder().from("CentOS 6.5 x64", "CentOS").build();
+      os = OperatingSystem.builder().from("6.5 x64", "CentOS").build();
 
       assertEquals(os.getDistribution(), Distribution.CENTOS);
       assertEquals(os.getVersion(), "6.5");
       assertEquals(os.getArch(), "x64");
       assertTrue(os.is64bit());
 
-      os = OperatingSystem.builder().from("CentOS 6.5 x64", "Centos").build();
+      os = OperatingSystem.builder().from("6.5 x64", "Centos").build();
 
       assertEquals(os.getDistribution(), Distribution.CENTOS);
       assertEquals(os.getVersion(), "6.5");
@@ -61,7 +79,7 @@ public class OperatingSystemTest {
    }
 
    public void testParseNoArch() {
-      OperatingSystem os = OperatingSystem.builder().from("Ubuntu 12.10", "Ubuntu").build();
+      OperatingSystem os = OperatingSystem.builder().from("12.10", "Ubuntu").build();
 
       assertEquals(os.getDistribution(), Distribution.UBUNTU);
       assertEquals(os.getVersion(), "12.10");
@@ -70,7 +88,7 @@ public class OperatingSystemTest {
    }
 
    public void testParseNoVersion() {
-      OperatingSystem os = OperatingSystem.builder().from("Ubuntu x64", "Ubuntu").build();
+      OperatingSystem os = OperatingSystem.builder().from("x64", "Ubuntu").build();
 
       assertEquals(os.getDistribution(), Distribution.UBUNTU);
       assertEquals(os.getVersion(), "");
@@ -79,7 +97,7 @@ public class OperatingSystemTest {
    }
 
    public void testParseUnknownDistribution() {
-      OperatingSystem os = OperatingSystem.builder().from("Ubuntu 12.04 x64", "Foo").build();
+      OperatingSystem os = OperatingSystem.builder().from("12.04 x64", "Foo").build();
 
       assertEquals(os.getDistribution(), Distribution.UNRECOGNIZED);
       assertEquals(os.getVersion(), "12.04");

--- a/digitalocean/src/test/resources/image1.json
+++ b/digitalocean/src/test/resources/image1.json
@@ -5,6 +5,8 @@
     "name" : "Arch Linux 2013.05 x32",
     "distribution" : "Arch Linux",
     "public" : true,
-    "slug" : "arch-linux-x32"
+    "slug" : "arch-linux-x32",
+    "regions": [1, 2, 3],
+    "region_slugs": ["nyc1", "ams1", "sfo1"]
   }
 }

--- a/digitalocean/src/test/resources/image2.json
+++ b/digitalocean/src/test/resources/image2.json
@@ -5,6 +5,8 @@
     "name" : "Fedora 17 x64 Desktop",
     "distribution" : "Fedora",
     "public" : true,
-    "slug" : "fedora-17-x64"
+    "slug" : "fedora-17-x64",
+    "regions": [1, 2, 3],
+    "region_slugs": ["nyc1", "ams1", "sfo1"]
   }
 }

--- a/digitalocean/src/test/resources/image3.json
+++ b/digitalocean/src/test/resources/image3.json
@@ -5,6 +5,8 @@
     "name" : "Dokku on Ubuntu 13.04 0.2.0rc3",
     "distribution" : "Ubuntu",
     "public" : true,
-    "slug" : null
+    "slug" : null,
+    "regions": [1, 2, 3],
+    "region_slugs": ["nyc1", "ams1", "sfo1"]
   }
 }

--- a/digitalocean/src/test/resources/images.json
+++ b/digitalocean/src/test/resources/images.json
@@ -6,21 +6,27 @@
          "name":"CentOS 5.8 x64",
          "slug":"centos-58-x64",
          "distribution":"CentOS",
-         "public":true
+         "public":true,
+         "regions": [1, 2, 3],
+         "region_slugs": ["nyc1", "ams1", "sfo1"]
       },
       {
          "id":1602,
          "name":"CentOS 5.8 x32",
          "slug":"centos-58-x32",
          "distribution":"CentOS",
-         "public":true
+         "public":true,
+         "regions": [1, 2, 3],
+         "region_slugs": ["nyc1", "ams1", "sfo1"]
       },
       {
          "id":12573,
          "name":"Debian 6.0 x64",
          "slug":null,
          "distribution":"Debian",
-         "public":true
+         "public":true,
+         "regions": [1, 2, 3],
+         "region_slugs": ["nyc1", "ams1", "sfo1"]
       }
    ]
 }


### PR DESCRIPTION
DigitalOcean has changed the name of its images. Now the distribution type is no longer part of the name. This change properly builds the OperatingSystem and Image objects so no information is lost.

Live tests results: *Tests run: 57, Failures: 0, Errors: 0, Skipped: 0*