### PR TITLE
Add template option to specify direct (unmapped) ports

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -54,6 +54,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    protected Optional<List<String>> commands = Optional.absent();
    protected Optional<Map<String, String>> volumes = Optional.absent();
    protected Optional<List<String>> env = Optional.absent();
+   protected Optional<List<Integer>> directPorts = Optional.absent();
 
    @Override
    public DockerTemplateOptions clone() {
@@ -84,10 +85,13 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
          }
          if (cpuShares.isPresent()) {
              eTo.cpuShares(cpuShares.get());
-          }
+         }
          if (env.isPresent()) {
              eTo.env(env.get());
-          }
+         }
+         if (directPorts.isPresent()) {
+             eTo.directPorts(directPorts.get());
+         }
       }
    }
 
@@ -104,12 +108,13 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
               equal(this.memory, that.memory) &&
               equal(this.commands, that.commands) &&
               equal(this.cpuShares, that.cpuShares) &&
-              equal(this.env, that.env);
+              equal(this.env, that.env) &&
+              equal(this.directPorts, that.directPorts);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(super.hashCode(), volumes, hostname, dns, memory, commands, cpuShares, env);
+      return Objects.hashCode(super.hashCode(), volumes, hostname, dns, memory, commands, cpuShares, env, directPorts);
    }
 
    @Override
@@ -122,6 +127,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
               .add("commands", commands)
               .add("volumes", volumes)
               .add("env", env)
+              .add("directPorts", directPorts)
               .toString();
    }
 
@@ -168,9 +174,12 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       return this;
    }
 
-   public Optional<Map<String, String>> getVolumes() {
-      return volumes;
+   public DockerTemplateOptions directPorts(List<Integer> ports) {
+      this.directPorts = Optional.<List<Integer>> of(ImmutableList.copyOf(ports));
+      return this;
    }
+
+   public Optional<Map<String, String>> getVolumes() { return volumes; }
 
    public Optional<String> getDns() { return dns; }
 
@@ -178,25 +187,23 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
 
    public Optional<Integer> getMemory() { return memory; }
 
-   public Optional<List<String>> getCommands() {
-      return commands;
-   }
+   public Optional<List<String>> getCommands() { return commands; }
 
    public Optional<Integer> getCpuShares() { return cpuShares; }
 
-   public Optional<List<String>> getEnv() {
-      return env;
-   }
+   public Optional<List<String>> getEnv() { return env; }
+
+   public Optional<List<Integer>> getDirectPorts() { return directPorts; }
 
    public static class Builder {
 
-       /**
-        * @see DockerTemplateOptions#volumes(java.util.Map)
-        */
-       public static DockerTemplateOptions volumes(Map<String, String> volumes) {
-          DockerTemplateOptions options = new DockerTemplateOptions();
-          return DockerTemplateOptions.class.cast(options.volumes(volumes));
-       }
+      /**
+       * @see DockerTemplateOptions#volumes(java.util.Map)
+       */
+      public static DockerTemplateOptions volumes(Map<String, String> volumes) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return DockerTemplateOptions.class.cast(options.volumes(volumes));
+      }
 
       /**
        * @see DockerTemplateOptions#dns(String)
@@ -249,6 +256,14 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       public static DockerTemplateOptions env(List<String> env) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return DockerTemplateOptions.class.cast(options.env(env));
+      }
+
+      /**
+       * @see DockerTemplateOptions#directPorts(java.util.List)
+       */
+      public static DockerTemplateOptions directPorts(List<Integer> directPorts) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return DockerTemplateOptions.class.cast(options.directPorts(directPorts));
       }
 
       // methods that only facilitate returning the correct object type

--- a/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -54,7 +54,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    protected Optional<List<String>> commands = Optional.absent();
    protected Optional<Map<String, String>> volumes = Optional.absent();
    protected Optional<List<String>> env = Optional.absent();
-   protected Optional<List<Integer>> directPorts = Optional.absent();
+   protected Optional<Map<Integer, Integer>> portBindings = Optional.absent();
 
    @Override
    public DockerTemplateOptions clone() {
@@ -89,8 +89,8 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
          if (env.isPresent()) {
              eTo.env(env.get());
          }
-         if (directPorts.isPresent()) {
-             eTo.directPorts(directPorts.get());
+         if (portBindings.isPresent()) {
+             eTo.portBindings(portBindings.get());
          }
       }
    }
@@ -109,12 +109,12 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
               equal(this.commands, that.commands) &&
               equal(this.cpuShares, that.cpuShares) &&
               equal(this.env, that.env) &&
-              equal(this.directPorts, that.directPorts);
+              equal(this.portBindings, that.portBindings);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(super.hashCode(), volumes, hostname, dns, memory, commands, cpuShares, env, directPorts);
+      return Objects.hashCode(super.hashCode(), volumes, hostname, dns, memory, commands, cpuShares, env, portBindings);
    }
 
    @Override
@@ -127,14 +127,14 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
               .add("commands", commands)
               .add("volumes", volumes)
               .add("env", env)
-              .add("directPorts", directPorts)
+              .add("portBindings", portBindings)
               .toString();
    }
 
    public static final DockerTemplateOptions NONE = new DockerTemplateOptions();
 
    public DockerTemplateOptions volumes(Map<String, String> volumes) {
-      this.volumes = Optional.<Map<String, String>> of(ImmutableMap.copyOf(volumes));
+      this.volumes = Optional.<Map<String, String>>of(ImmutableMap.copyOf(checkNotNull(volumes, "volumes")));
       return this;
    }
 
@@ -154,13 +154,11 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    }
 
    public TemplateOptions commands(Iterable<String> commands) {
-      for (String command : checkNotNull(commands, "commands"))
-         checkNotNull(command, "all commands must be non-empty");
-      this.commands = Optional.<List<String>> of(ImmutableList.copyOf(commands));
+      this.commands = Optional.<List<String>>of(ImmutableList.copyOf(checkNotNull(commands, "commands")));
       return this;
    }
 
-   public TemplateOptions commands(String... commands) {
+   public TemplateOptions commands(String...commands) {
       return commands(ImmutableList.copyOf(checkNotNull(commands, "commands")));
    }
 
@@ -169,13 +167,27 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       return this;
    }
 
-   public DockerTemplateOptions env(List<String> env) {
-      this.env = Optional.<List<String>> of(ImmutableList.copyOf(env));
+   public DockerTemplateOptions env(Iterable<String> env) {
+      this.env = Optional.<List<String>>of(ImmutableList.copyOf(checkNotNull(env, "env")));
       return this;
    }
 
-   public DockerTemplateOptions directPorts(List<Integer> ports) {
-      this.directPorts = Optional.<List<Integer>> of(ImmutableList.copyOf(ports));
+   public DockerTemplateOptions env(String...env) {
+      return env(ImmutableList.copyOf(checkNotNull(env, "env")));
+   }
+
+   /**
+    * Set port bindings between the Docker host and a container.
+    * <p>
+    * The {@link Map} keys are host ports number, and the value for an entry is the
+    * container port number. This is the same order as the arguments for the
+    * {@code --publish} command-line option to {@code docker run} which is
+    * {@code hostPort:containerPort}.
+    *
+    * @param portBindings the map of host to container port bindings
+    */
+   public DockerTemplateOptions portBindings(Map<Integer, Integer> portBindings) {
+      this.portBindings = Optional.<Map<Integer, Integer>>of(ImmutableMap.copyOf(checkNotNull(portBindings, "portBindings")));
       return this;
    }
 
@@ -193,12 +205,12 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
 
    public Optional<List<String>> getEnv() { return env; }
 
-   public Optional<List<Integer>> getDirectPorts() { return directPorts; }
+   public Optional<Map<Integer, Integer>> getPortBindings() { return portBindings; }
 
    public static class Builder {
 
       /**
-       * @see DockerTemplateOptions#volumes(java.util.Map)
+       * @see DockerTemplateOptions#volumes(Map)
        */
       public static DockerTemplateOptions volumes(Map<String, String> volumes) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -222,7 +234,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see DockerTemplateOptions#memory
+       * @see DockerTemplateOptions#memory(int)
        */
       public static DockerTemplateOptions memory(int memory) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -230,13 +242,16 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see DockerTemplateOptions#commands(Iterable)
+       * @see DockerTemplateOptions#commands(String[])
        */
-      public static DockerTemplateOptions commands(String... commands) {
+      public static DockerTemplateOptions commands(String...commands) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return DockerTemplateOptions.class.cast(options.commands(commands));
       }
 
+      /**
+       * @see DockerTemplateOptions#commands(Iterable)
+       */
       public static DockerTemplateOptions commands(Iterable<String> commands) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return DockerTemplateOptions.class.cast(options.commands(commands));
@@ -251,19 +266,27 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see DockerTemplateOptions#env(java.util.List)
+       * @see DockerTemplateOptions#env(String[])
        */
-      public static DockerTemplateOptions env(List<String> env) {
+      public static DockerTemplateOptions env(String...env) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return DockerTemplateOptions.class.cast(options.env(env));
       }
 
       /**
-       * @see DockerTemplateOptions#directPorts(java.util.List)
+       * @see DockerTemplateOptions#env(Iterable)
        */
-      public static DockerTemplateOptions directPorts(List<Integer> directPorts) {
+      public static DockerTemplateOptions env(Iterable<String> env) {
          DockerTemplateOptions options = new DockerTemplateOptions();
-         return DockerTemplateOptions.class.cast(options.directPorts(directPorts));
+         return DockerTemplateOptions.class.cast(options.env(env));
+      }
+
+      /**
+       * @see DockerTemplateOptions#portBindings(Map)
+       */
+      public static DockerTemplateOptions portBindings(Map<Integer, Integer> portBindings) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return DockerTemplateOptions.class.cast(options.portBindings(portBindings));
       }
 
       // methods that only facilitate returning the correct object type

--- a/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -19,6 +19,8 @@ package org.jclouds.docker.compute.strategy;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.find;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,7 +51,9 @@ import org.jclouds.logging.Logger;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -135,6 +139,14 @@ public class DockerComputeServiceAdapter implements
       HostConfig.Builder hostConfigBuilder = HostConfig.builder()
               .publishAllPorts(true)
               .privileged(true);
+
+      if (templateOptions.getDirectPorts().isPresent()) {
+         Map<String, List<Map<String, String>>> portBindings = Maps.newHashMap();
+         for (Integer port : templateOptions.getDirectPorts().get()) {
+            portBindings.put(port + "/tcp", Lists.<Map<String, String>>newArrayList(ImmutableMap.of("HostPort", Integer.toString(port))));
+         }
+         hostConfigBuilder.portBindings(portBindings);
+      }
 
       if (templateOptions.getDns().isPresent()) {
          hostConfigBuilder.dns(templateOptions.getDns().get());


### PR DESCRIPTION
Allows container port to map directly to a specific port on the host for e.g. public web servers on 80 or 443.

```Java
DockerTemplateOptions options = ...
options.portBindings(ImmutableMap.of(80, 80, 443, 443));
```