### PR TITLE
JCLOUDS-913 CloudSigma2 Adding password to returned login credentials

### DIFF
--- a/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/compute/strategy/CloudSigma2ComputeServiceAdapter.java
+++ b/cloudsigma2/src/main/java/org/jclouds/cloudsigma2/compute/strategy/CloudSigma2ComputeServiceAdapter.java
@@ -185,6 +185,8 @@ public class CloudSigma2ComputeServiceAdapter implements
       try {
          logger.debug(">> creating server...");
 
+         String password = Optional.fromNullable(options.getVncPassword()).or(defaultVncPassword);
+
          serverInfo = api.createServer(new ServerInfo.Builder()
                .name(name)
                .cpu((int) hardware.getProcessors().get(0).getSpeed())
@@ -193,12 +195,12 @@ public class CloudSigma2ComputeServiceAdapter implements
                .nics(nics)
                .meta(metadata)
                .tags(tagIds)
-               .vncPassword(Optional.fromNullable(options.getVncPassword()).or(defaultVncPassword)).build());
+               .vncPassword(password).build());
 
          api.startServer(serverInfo.getUuid());
 
          return new NodeAndInitialCredentials<ServerInfo>(serverInfo, serverInfo.getUuid(), LoginCredentials.builder()
-               .build());
+               .password(password).build());
       } catch (Exception ex) {
          try {
             if (serverInfo != null) {


### PR DESCRIPTION
Password is not currently added to the login credentials.
This is done in other providers adapters.