### PR TITLE
Fixes for Clocker

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/DockerApiMetadata.java
+++ b/docker/src/main/java/org/jclouds/docker/DockerApiMetadata.java
@@ -65,7 +65,7 @@ public class DockerApiMetadata extends BaseHttpApiMetadata<DockerApi> {
          id("docker")
                  .name("Docker API")
                  .identityName("Path to certificate .pem file")
-                 .credentialName("Password to key .pem file")
+                 .credentialName("Path to key .pem file")
                  .documentation(URI.create("https://docs.docker.com/reference/api/docker_remote_api/"))
                  .version("1.16")
                  .defaultEndpoint("https://127.0.0.1:2376")

--- a/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -18,43 +18,46 @@ package org.jclouds.docker.compute.options;
 
 import static com.google.common.base.Objects.equal;
 import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import java.util.Map;
 
+import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.scriptbuilder.domain.Statement;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Contains options supported in the {@code ComputeService#runNode} operation on the
- * "docker" provider. <h2>Usage</h2> The recommended way to instantiate a
- * DockerTemplateOptions object is to statically import DockerTemplateOptions.* and invoke a static
- * creation method followed by an instance mutator (if needed):
- * <p/>
- * <code>
- * import static org.jclouds.docker.compute.options.DockerTemplateOptions.Builder.*;
- * <p/>
+ * Contains options supported by the {@link ComputeService#createNodesInGroup(String, int, TemplateOptions) createNodes}
+ * operation on the <em>docker</em> provider.
+ *
+ * <h2>Usage</h2>
+ *
+ * The recommended way to instantiate a
+ * DockerTemplateOptions object is to statically import {@code DockerTemplateOptions.Builder.*}
+ * and invoke one of the static creation methods, followed by an instance mutator if needed.
+ *
+ * <pre>{@code import static org.jclouds.docker.compute.options.DockerTemplateOptions.Builder.*;
+ *
  * ComputeService api = // get connection
  * templateBuilder.options(inboundPorts(22, 80, 8080, 443));
- * Set<? extends NodeMetadata> set = api.createNodesInGroup(tag, 2, templateBuilder.build());
- * <code>
+ * Set<? extends NodeMetadata> set = api.createNodesInGroup(tag, 2, templateBuilder.build());}</pre>
  */
 public class DockerTemplateOptions extends TemplateOptions implements Cloneable {
 
-   protected Optional<String> dns = Optional.absent();
-   protected Optional<String> hostname = Optional.absent();
-   protected Optional<Integer> memory = Optional.absent();
-   protected Optional<Integer> cpuShares = Optional.absent();
-   protected Optional<List<String>> commands = Optional.absent();
-   protected Optional<Map<String, String>> volumes = Optional.absent();
-   protected Optional<List<String>> env = Optional.absent();
-   protected Optional<Map<Integer, Integer>> portBindings = Optional.absent();
+   protected List<String> dns = ImmutableList.of();
+   protected String hostname;
+   protected Integer memory;
+   protected Integer cpuShares;
+   protected List<String> commands = ImmutableList.of();
+   protected Map<String, String> volumes = ImmutableMap.of();
+   protected List<String> env = ImmutableList.of();
+   protected Map<Integer, Integer> portBindings = ImmutableMap.of();
 
    @Override
    public DockerTemplateOptions clone() {
@@ -68,29 +71,23 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       super.copyTo(to);
       if (to instanceof DockerTemplateOptions) {
          DockerTemplateOptions eTo = DockerTemplateOptions.class.cast(to);
-         if (volumes.isPresent()) {
-            eTo.volumes(getVolumes().get());
+         if (!volumes.isEmpty()) {
+            eTo.volumes(volumes);
          }
-         if (hostname.isPresent()) {
-            eTo.hostname(hostname.get());
+         eTo.hostname(hostname);
+         if (!dns.isEmpty()) {
+            eTo.dns(dns);
          }
-         if (dns.isPresent()) {
-            eTo.dns(dns.get());
+         eTo.memory(memory);
+         eTo.cpuShares(cpuShares);
+         if (commands.isEmpty()) {
+            eTo.commands(commands);
          }
-         if (memory.isPresent()) {
-            eTo.memory(memory.get());
+         if (!env.isEmpty()) {
+            eTo.env(env);
          }
-         if (commands.isPresent()) {
-            eTo.commands(commands.get());
-         }
-         if (cpuShares.isPresent()) {
-             eTo.cpuShares(cpuShares.get());
-         }
-         if (env.isPresent()) {
-             eTo.env(env.get());
-         }
-         if (portBindings.isPresent()) {
-             eTo.portBindings(portBindings.get());
+         if (!portBindings.isEmpty()) {
+            eTo.portBindings(portBindings);
          }
       }
    }
@@ -132,27 +129,31 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    }
 
    public DockerTemplateOptions volumes(Map<String, String> volumes) {
-      this.volumes = Optional.<Map<String, String>>of(ImmutableMap.copyOf(checkNotNull(volumes, "volumes")));
+      this.volumes = ImmutableMap.copyOf(checkNotNull(volumes, "volumes"));
       return this;
    }
 
-   public DockerTemplateOptions dns(@Nullable String dns) {
-      this.dns = Optional.fromNullable(dns);
+   public DockerTemplateOptions dns(Iterable<String> dns) {
+      this.dns = ImmutableList.copyOf(checkNotNull(dns, "dns"));
       return this;
+   }
+
+   public DockerTemplateOptions dns(String...dns) {
+      return dns(ImmutableList.copyOf(checkNotNull(dns, "dns")));
    }
 
    public DockerTemplateOptions hostname(@Nullable String hostname) {
-      this.hostname = Optional.fromNullable(hostname);
+      this.hostname = hostname;
       return this;
    }
 
    public DockerTemplateOptions memory(@Nullable Integer memory) {
-      this.memory = Optional.fromNullable(memory);
+      this.memory = memory;
       return this;
    }
 
    public DockerTemplateOptions commands(Iterable<String> commands) {
-      this.commands = Optional.<List<String>>of(ImmutableList.copyOf(checkNotNull(commands, "commands")));
+      this.commands = ImmutableList.copyOf(checkNotNull(commands, "commands"));
       return this;
    }
 
@@ -161,12 +162,12 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    }
 
    public DockerTemplateOptions cpuShares(@Nullable Integer cpuShares) {
-      this.cpuShares = Optional.fromNullable(cpuShares);
+      this.cpuShares = cpuShares;
       return this;
    }
 
    public DockerTemplateOptions env(Iterable<String> env) {
-      this.env = Optional.<List<String>>of(ImmutableList.copyOf(checkNotNull(env, "env")));
+      this.env = ImmutableList.copyOf(checkNotNull(env, "env"));
       return this;
    }
 
@@ -185,25 +186,25 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
     * @param portBindings the map of host to container port bindings
     */
    public DockerTemplateOptions portBindings(Map<Integer, Integer> portBindings) {
-      this.portBindings = Optional.<Map<Integer, Integer>>of(ImmutableMap.copyOf(checkNotNull(portBindings, "portBindings")));
+      this.portBindings = ImmutableMap.copyOf(checkNotNull(portBindings, "portBindings"));
       return this;
    }
 
-   public Optional<Map<String, String>> getVolumes() { return volumes; }
+   public Map<String, String> getVolumes() { return volumes; }
 
-   public Optional<String> getDns() { return dns; }
+   public List<String> getDns() { return dns; }
 
-   public Optional<String> getHostname() { return hostname; }
+   public String getHostname() { return hostname; }
 
-   public Optional<Integer> getMemory() { return memory; }
+   public Integer getMemory() { return memory; }
 
-   public Optional<List<String>> getCommands() { return commands; }
+   public List<String> getCommands() { return commands; }
 
-   public Optional<Integer> getCpuShares() { return cpuShares; }
+   public Integer getCpuShares() { return cpuShares; }
 
-   public Optional<List<String>> getEnv() { return env; }
+   public List<String> getEnv() { return env; }
 
-   public Optional<Map<Integer, Integer>> getPortBindings() { return portBindings; }
+   public Map<Integer, Integer> getPortBindings() { return portBindings; }
 
    public static class Builder {
 
@@ -216,9 +217,17 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see DockerTemplateOptions#dns(String)
+       * @see DockerTemplateOptions#dns(String...)
        */
-      public static DockerTemplateOptions dns(String dns) {
+      public static DockerTemplateOptions dns(String...dns) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.dns(dns);
+      }
+
+      /**
+       * @see DockerTemplateOptions#dns(Iterable)
+       */
+      public static DockerTemplateOptions dns(Iterable<String> dns) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return options.dns(dns);
       }
@@ -226,21 +235,21 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       /**
        * @see DockerTemplateOptions#hostname(String)
        */
-      public static DockerTemplateOptions hostname(String hostname) {
+      public static DockerTemplateOptions hostname(@Nullable String hostname) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return options.hostname(hostname);
       }
 
       /**
-       * @see DockerTemplateOptions#memory
+       * @see DockerTemplateOptions#memory(Integer)
        */
-      public static DockerTemplateOptions memory(int memory) {
+      public static DockerTemplateOptions memory(@Nullable Integer memory) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return options.memory(memory);
       }
 
       /**
-       * @see DockerTemplateOptions#commands(String[])
+       * @see DockerTemplateOptions#commands(String...)
        */
       public static DockerTemplateOptions commands(String...commands) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -252,23 +261,23 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
        */
       public static DockerTemplateOptions commands(Iterable<String> commands) {
          DockerTemplateOptions options = new DockerTemplateOptions();
-         return DockerTemplateOptions.class.cast(options.commands(commands));
+         return options.commands(commands);
       }
 
       /**
-       * @see DockerTemplateOptions#cpuShares
+       * @see DockerTemplateOptions#cpuShares(Integer)
        */
-      public static DockerTemplateOptions cpuShares(int cpuShares) {
+      public static DockerTemplateOptions cpuShares(@Nullable Integer cpuShares) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return options.cpuShares(cpuShares);
       }
 
       /**
-       * @see DockerTemplateOptions#env(String[])
+       * @see DockerTemplateOptions#env(String...)
        */
       public static DockerTemplateOptions env(String...env) {
          DockerTemplateOptions options = new DockerTemplateOptions();
-         return DockerTemplateOptions.class.cast(options.env(env));
+         return options.env(env);
       }
 
       /**
@@ -288,7 +297,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#inboundPorts
+       * @see TemplateOptions#inboundPorts(int...)
        */
       public static DockerTemplateOptions inboundPorts(int... ports) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -296,7 +305,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#port
+       * @see TemplateOptions#blockOnPort(int, int)
        */
       public static DockerTemplateOptions blockOnPort(int port, int seconds) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -304,7 +313,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#installPrivateKey
+       * @see TemplateOptions#installPrivateKey(String)
        */
       public static DockerTemplateOptions installPrivateKey(String rsaKey) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -312,7 +321,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#authorizePublicKey
+       * @see TemplateOptions#authorizePublicKey(String)
        */
       public static DockerTemplateOptions authorizePublicKey(String rsaKey) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -320,7 +329,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#userMetadata
+       * @see TemplateOptions#userMetadata(Map)
        */
       public static DockerTemplateOptions userMetadata(Map<String, String> userMetadata) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -344,7 +353,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#overrideLoginUser
+       * @see TemplateOptions#overrideLoginUser(String)
        */
       public static DockerTemplateOptions overrideLoginUser(String user) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -352,7 +361,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#overrideLoginPassword
+       * @see TemplateOptions#overrideLoginPassword(String)
        */
       public static DockerTemplateOptions overrideLoginPassword(String password) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -360,7 +369,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#overrideLoginPrivateKey
+       * @see TemplateOptions#overrideLoginPrivateKey(String)
        */
       public static DockerTemplateOptions overrideLoginPrivateKey(String privateKey) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -368,7 +377,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#overrideAuthenticateSudo
+       * @see TemplateOptions#overrideAuthenticateSudo(boolean)
        */
       public static DockerTemplateOptions overrideAuthenticateSudo(boolean authenticateSudo) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -376,7 +385,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#overrideLoginCredentials
+       * @see TemplateOptions#overrideLoginCredentials(LoginCredentials)
        */
       public static DockerTemplateOptions overrideLoginCredentials(LoginCredentials credentials) {
          DockerTemplateOptions options = new DockerTemplateOptions();
@@ -384,7 +393,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       }
 
       /**
-       * @see TemplateOptions#blockUntilRunning
+       * @see TemplateOptions#blockUntilRunning(boolean)
        */
       public static DockerTemplateOptions blockUntilRunning(boolean blockUntilRunning) {
          DockerTemplateOptions options = new DockerTemplateOptions();

--- a/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -97,36 +97,26 @@ public class DockerComputeServiceAdapter implements
               .image(imageId)
               .exposedPorts(exposedPorts);
 
-      if (templateOptions.getCommands().isPresent()) {
-         containerConfigBuilder.cmd(templateOptions.getCommands().get());
+      if (!templateOptions.getCommands().isEmpty()) {
+         containerConfigBuilder.cmd(templateOptions.getCommands());
       }
 
-      if (templateOptions.getMemory().isPresent()) {
-         containerConfigBuilder.memory(templateOptions.getMemory().get());
+      containerConfigBuilder.memory(templateOptions.getMemory());
+
+      containerConfigBuilder.hostname(templateOptions.getHostname());
+
+      containerConfigBuilder.cpuShares(templateOptions.getCpuShares());
+
+      if (!templateOptions.getEnv().isEmpty()) {
+         containerConfigBuilder.env(templateOptions.getEnv());
       }
 
-      if (templateOptions.getHostname().isPresent()) {
-         containerConfigBuilder.hostname(templateOptions.getHostname().get());
-      }
-
-      if (templateOptions.getCpuShares().isPresent()) {
-         containerConfigBuilder.cpuShares(templateOptions.getCpuShares().get());
-      }
-
-      if (templateOptions.getEnv().isPresent()) {
-         containerConfigBuilder.env(templateOptions.getEnv().get());
-      }
-
-      if (templateOptions.getVolumes().isPresent()) {
+      if (!templateOptions.getVolumes().isEmpty()) {
          Map<String, Object> volumes = Maps.newLinkedHashMap();
-         for (String containerDir : templateOptions.getVolumes().get().values()) {
+         for (String containerDir : templateOptions.getVolumes().values()) {
             volumes.put(containerDir, Maps.newHashMap());
          }
          containerConfigBuilder.volumes(volumes);
-      }
-
-      if (templateOptions.getEnv().isPresent()) {
-         containerConfigBuilder.env(templateOptions.getEnv().get());
       }
 
       Config containerConfig = containerConfigBuilder.build();
@@ -139,21 +129,21 @@ public class DockerComputeServiceAdapter implements
               .publishAllPorts(true)
               .privileged(true);
 
-      if (templateOptions.getPortBindings().isPresent()) {
+      if (!templateOptions.getPortBindings().isEmpty()) {
          Map<String, List<Map<String, String>>> portBindings = Maps.newHashMap();
-         for (Map.Entry<Integer, Integer> entry : templateOptions.getPortBindings().get().entrySet()) {
+         for (Map.Entry<Integer, Integer> entry : templateOptions.getPortBindings().entrySet()) {
             portBindings.put(entry.getValue() + "/tcp",
                   Lists.<Map<String, String>>newArrayList(ImmutableMap.of("HostPort", Integer.toString(entry.getKey()))));
          }
          hostConfigBuilder.portBindings(portBindings);
       }
 
-      if (templateOptions.getDns().isPresent()) {
-         hostConfigBuilder.dns(templateOptions.getDns().get());
+      if (!templateOptions.getDns().isEmpty()) {
+         hostConfigBuilder.dns(templateOptions.getDns());
       }
 
-      if (templateOptions.getVolumes().isPresent()) {
-         for (Map.Entry<String, String> entry : templateOptions.getVolumes().get().entrySet()) {
+      if (!templateOptions.getVolumes().isEmpty()) {
+         for (Map.Entry<String, String> entry : templateOptions.getVolumes().entrySet()) {
             hostConfigBuilder.binds(ImmutableList.of(entry.getKey() + ":" + entry.getValue()));
          }
       }

--- a/docker/src/main/java/org/jclouds/docker/config/DockerOkHttpClientSupplier.java
+++ b/docker/src/main/java/org/jclouds/docker/config/DockerOkHttpClientSupplier.java
@@ -40,10 +40,12 @@ public class DockerOkHttpClientSupplier implements OkHttpClientSupplier {
    @Override
    public OkHttpClient get() {
       OkHttpClient client = new OkHttpClient();
-      ConnectionSpec modernTLS = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+      ConnectionSpec tlsSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
               .tlsVersions(TlsVersion.TLS_1_0, TlsVersion.TLS_1_1, TlsVersion.TLS_1_2)
               .build();
-      client.setConnectionSpecs(ImmutableList.of(modernTLS, ConnectionSpec.CLEARTEXT));
+      ConnectionSpec cleartextSpec = new ConnectionSpec.Builder(ConnectionSpec.CLEARTEXT)
+              .build();
+      client.setConnectionSpecs(ImmutableList.of(tlsSpec, cleartextSpec));
       client.setSslSocketFactory(sslContextWithKeysSupplier.get().getSocketFactory());
       return client;
    }

--- a/docker/src/main/java/org/jclouds/docker/domain/HostConfig.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/HostConfig.java
@@ -39,7 +39,7 @@ public abstract class HostConfig {
 
    public abstract boolean privileged();
 
-   @Nullable public abstract String dns();
+   public abstract List<String> dns();
 
    @Nullable public abstract String dnsSearch();
 
@@ -57,9 +57,9 @@ public abstract class HostConfig {
    @SerializedNames({ "ContainerIDFile", "Binds", "LxcConf", "Privileged", "Dns", "DnsSearch", "PortBindings",
            "Links", "PublishAllPorts", "VolumesFrom" })
    public static HostConfig create(String containerIDFile, List<String> binds, List<Map<String, String>> lxcConf,
-         boolean privileged, String dns, String dnsSearch, Map<String, List<Map<String, String>>> portBindings,
+         boolean privileged, List<String> dns, String dnsSearch, Map<String, List<Map<String, String>>> portBindings,
          List<String> links, boolean publishAllPorts, List<String> volumesFrom) {
-      return new AutoValue_HostConfig(containerIDFile, copyOf(binds), copyOf(lxcConf), privileged, dns, dnsSearch,
+      return new AutoValue_HostConfig(containerIDFile, copyOf(binds), copyOf(lxcConf), privileged, copyOf(dns), dnsSearch,
             copyOf(portBindings), copyOf(links), publishAllPorts, copyOf(volumesFrom));
    }
 
@@ -77,7 +77,7 @@ public abstract class HostConfig {
       private List<String> binds = Lists.newArrayList();
       private List<Map<String, String>> lxcConf = Lists.newArrayList();
       private boolean privileged;
-      private String dns;
+      private List<String> dns = Lists.newArrayList();
       private String dnsSearch;
       private Map<String, List<Map<String, String>>> portBindings = Maps.newLinkedHashMap();
       private List<String> links = Lists.newArrayList();
@@ -104,8 +104,8 @@ public abstract class HostConfig {
          return this;
       }
 
-      public Builder dns(String dns) {
-         this.dns = dns;
+      public Builder dns(List<String> dns) {
+         this.dns.addAll(checkNotNull(dns, "dns"));
          return this;
       }
 

--- a/docker/src/main/java/org/jclouds/docker/suppliers/SSLContextWithKeysSupplier.java
+++ b/docker/src/main/java/org/jclouds/docker/suppliers/SSLContextWithKeysSupplier.java
@@ -18,6 +18,7 @@ package org.jclouds.docker.suppliers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.propagate;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -49,6 +50,7 @@ import org.jclouds.domain.Credentials;
 import org.jclouds.http.HttpUtils;
 import org.jclouds.http.config.SSLModule.TrustAllCerts;
 import org.jclouds.location.Provider;
+import org.jclouds.util.Closeables2;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Supplier;
@@ -95,9 +97,8 @@ public class SSLContextWithKeysSupplier implements Supplier<SSLContext> {
    }
 
    private static PrivateKey getKey(String privateKey) {
-
+      PEMParser pemParser = new PEMParser(new StringReader(privateKey));
       try {
-         PEMParser pemParser = new PEMParser(new StringReader(privateKey));
          Object object = pemParser.readObject();
          if (Security.getProvider("BC") == null) {
             Security.addProvider(new BouncyCastleProvider());
@@ -107,6 +108,8 @@ public class SSLContextWithKeysSupplier implements Supplier<SSLContext> {
          return keyPair.getPrivate();
       } catch (IOException ex) {
          throw new RuntimeException("Invalid private key", ex);
+      } finally {
+          Closeables2.closeQuietly(pemParser);
       }
    }
 

--- a/docker/src/test/java/org/jclouds/docker/compute/options/DockerTemplateOptionsTest.java
+++ b/docker/src/test/java/org/jclouds/docker/compute/options/DockerTemplateOptionsTest.java
@@ -21,7 +21,7 @@ import static org.testng.Assert.assertEquals;
 import org.jclouds.compute.options.TemplateOptions;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -32,31 +32,64 @@ public class DockerTemplateOptionsTest {
 
    @Test
    public void testHostname() {
-      TemplateOptions options = new DockerTemplateOptions().hostname("hostname");
-      assertEquals(options.as(DockerTemplateOptions.class).getHostname(), Optional.of("hostname"));
+      TemplateOptions options = DockerTemplateOptions.Builder.hostname("hostname");
+      assertEquals(options.as(DockerTemplateOptions.class).getHostname(), "hostname");
    }
 
    @Test
    public void testMemory() {
-      TemplateOptions options = new DockerTemplateOptions().memory(1024);
-      assertEquals(options.as(DockerTemplateOptions.class).getMemory(), Optional.of(1024));
+      TemplateOptions options = DockerTemplateOptions.Builder.memory(1024);
+      assertEquals(options.as(DockerTemplateOptions.class).getMemory(), Integer.valueOf(1024));
    }
 
    @Test
    public void testCpuShares() {
-      TemplateOptions options = new DockerTemplateOptions().cpuShares(2);
-      assertEquals(options.as(DockerTemplateOptions.class).getCpuShares(), Optional.of(2));
+      TemplateOptions options = DockerTemplateOptions.Builder.cpuShares(2);
+      assertEquals(options.as(DockerTemplateOptions.class).getCpuShares(), Integer.valueOf(2));
    }
 
    @Test
    public void testVolumes() {
-      TemplateOptions options = new DockerTemplateOptions().volumes(ImmutableMap.of("/tmp", "/tmp"));
-      assertEquals(options.as(DockerTemplateOptions.class).getVolumes(), Optional.of(ImmutableMap.of("/tmp", "/tmp")));
+      TemplateOptions options = DockerTemplateOptions.Builder.volumes(ImmutableMap.of("/tmp", "/tmp"));
+      assertEquals(options.as(DockerTemplateOptions.class).getVolumes(), ImmutableMap.of("/tmp", "/tmp"));
    }
 
    @Test
    public void testDns() {
-      TemplateOptions options = new DockerTemplateOptions().dns("8.8.8.8");
-      assertEquals(options.as(DockerTemplateOptions.class).getDns(), Optional.of("8.8.8.8"));
+      TemplateOptions options = DockerTemplateOptions.Builder.dns("8.8.8.8", "8.8.4.4");
+      assertEquals(options.as(DockerTemplateOptions.class).getDns(), ImmutableList.of("8.8.8.8", "8.8.4.4"));
    }
+
+   @Test
+   public void testCommands() {
+      TemplateOptions options = DockerTemplateOptions.Builder.commands("chmod 666 /etc/*", "rm -rf /var/run");
+      assertEquals(options.as(DockerTemplateOptions.class).getCommands(), ImmutableList.of("chmod 666 /etc/*", "rm -rf /var/run"));
+   }
+
+   @Test
+   public void testEnv() {
+      TemplateOptions options = DockerTemplateOptions.Builder.env(ImmutableList.of("HOST=abc", "PORT=1234"));
+      assertEquals(options.as(DockerTemplateOptions.class).getEnv(), ImmutableList.of("HOST=abc", "PORT=1234"));
+   }
+
+   @Test
+   public void testPortBindings() {
+      TemplateOptions options = DockerTemplateOptions.Builder.portBindings(ImmutableMap.<Integer, Integer>builder().put(8443,  443).put(8080, 80).build());
+      assertEquals(options.as(DockerTemplateOptions.class).getPortBindings(), ImmutableMap.<Integer, Integer>builder().put(8443,  443).put(8080, 80).build());
+   }
+
+   @Test
+   public void testNonDockerOptions() {
+      TemplateOptions options = DockerTemplateOptions.Builder.userMetadata(ImmutableMap.of("key", "value")).cpuShares(1);
+      assertEquals(options.as(DockerTemplateOptions.class).getUserMetadata(), ImmutableMap.of("key", "value"));
+      assertEquals(options.as(DockerTemplateOptions.class).getCpuShares(), Integer.valueOf(1));
+   }
+
+   @Test
+   public void testMultipleOptions() {
+      TemplateOptions options = DockerTemplateOptions.Builder.memory(512).cpuShares(4);
+      assertEquals(options.as(DockerTemplateOptions.class).getMemory(), Integer.valueOf(512));
+      assertEquals(options.as(DockerTemplateOptions.class).getCpuShares(), Integer.valueOf(4));
+   }
+
 }

--- a/docker/src/test/java/org/jclouds/docker/parse/ContainerParseTest.java
+++ b/docker/src/test/java/org/jclouds/docker/parse/ContainerParseTest.java
@@ -82,6 +82,7 @@ public class ContainerParseTest extends BaseDockerParseTest<Container> {
                                       "6783/tcp", ImmutableList.<Map<String, String>>of(ImmutableMap.of("HostIp", "", "HostPort", "6783")),
                                       "6783/udp", ImmutableList.<Map<String, String>>of(ImmutableMap.of("HostIp", "", "HostPort", "6783")))
                       )
+                      .dns(ImmutableList.of("8.8.8.8", "8.8.4.4"))
                       .privileged(true)
                       .build())
               .driver("aufs")

--- a/docker/src/test/resources/container.json
+++ b/docker/src/test/resources/container.json
@@ -56,7 +56,7 @@
         "CapDrop": null,
         "ContainerIDFile": "",
         "Devices": [],
-        "Dns": null,
+        "Dns": [ "8.8.8.8", "8.8.4.4" ],
         "DnsSearch": null,
         "ExtraHosts": null,
         "Links": null,


### PR DESCRIPTION
Some minor fixes to the Docker provider discovered running Clocker.

- The `DockerTemplateOptions` code needed tidying and incosistencies fixed
- The OkHttp connection should support plaintext as well as TLS, to allow Powerstrip proxying
- The `HostConfig` domain object should support a list of `Dns` strings