### PR TITLE
JCLOUDS-930: Fixup the test to expect "/".

### DIFF
--- a/jdbc/src/test/java/org/jclouds/jdbc/BaseJdbcBlobStoreTest.java
+++ b/jdbc/src/test/java/org/jclouds/jdbc/BaseJdbcBlobStoreTest.java
@@ -434,7 +434,7 @@ public abstract class BaseJdbcBlobStoreTest {
             .inDirectory("");
       PageSet<? extends StorageMetadata> res = blobStore.list(CONTAINER_NAME, options);
       assertTrue(res.size() == 1);
-      assertEquals(res.iterator().next().getName(), d);
+      assertEquals(res.iterator().next().getName(), d + "/");
    }
 
    @Test


### PR DESCRIPTION
After the change to address JCLOUDS-930, the tests need to expect that
a trailing slash is present in the common prefixes (the delimiter --
"/" -- is included).