### PR TITLE
JCLOUDS-996 fix NetworkMode location

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -58,6 +58,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    protected Map<String, String> volumes = ImmutableMap.of();
    protected List<String> env = ImmutableList.of();
    protected Map<Integer, Integer> portBindings = ImmutableMap.of();
+   protected String networkMode;
 
    @Override
    public DockerTemplateOptions clone() {
@@ -89,6 +90,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
          if (!portBindings.isEmpty()) {
             eTo.portBindings(portBindings);
          }
+         eTo.networkMode(networkMode);
       }
    }
 
@@ -190,6 +192,17 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       return this;
    }
 
+
+   /**
+    * Sets the networking mode for the container. Supported values are: bridge, host, and container:[name|id]
+    * @param networkMode
+    * @return this instance
+    */
+   public DockerTemplateOptions networkMode(@Nullable String networkMode) {
+      this.networkMode = networkMode;
+      return this;
+   }
+
    public Map<String, String> getVolumes() { return volumes; }
 
    public List<String> getDns() { return dns; }
@@ -205,6 +218,8 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    public List<String> getEnv() { return env; }
 
    public Map<Integer, Integer> getPortBindings() { return portBindings; }
+
+   public String getNetworkMode() { return networkMode; }
 
    public static class Builder {
 
@@ -294,6 +309,14 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       public static DockerTemplateOptions portBindings(Map<Integer, Integer> portBindings) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return options.portBindings(portBindings);
+      }
+
+      /**
+       * @see DockerTemplateOptions#hostname(String)
+       */
+      public static DockerTemplateOptions networkMode(@Nullable String networkMode) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.networkMode(networkMode);
       }
 
       /**

--- a/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -148,6 +148,8 @@ public class DockerComputeServiceAdapter implements
          }
       }
 
+      hostConfigBuilder.networkMode(templateOptions.getNetworkMode());
+
       HostConfig hostConfig = hostConfigBuilder.build();
 
       api.getContainerApi().startContainer(container.id(), hostConfig);

--- a/docker/src/main/java/org/jclouds/docker/domain/Config.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/Config.java
@@ -99,8 +99,6 @@ public abstract class Config {
 
    public abstract Map<String, String> restartPolicy();
 
-   @Nullable public abstract String networkMode();
-
    Config() {
    }
 
@@ -110,7 +108,7 @@ public abstract class Config {
                  "AttachStderr", "Tty", "OpenStdin", "StdinOnce", "Env", "Cmd", "Entrypoint", "Image", "Volumes",
                  "WorkingDir", "NetworkDisabled", "ExposedPorts", "SecurityOpts", "HostConfig", "Binds", "Links",
                  "LxcConf", "PortBindings", "PublishAllPorts", "Privileged", "Dns", "DnsSearch", "VolumesFrom",
-                 "CapAdd", "CapDrop", "RestartPolicy", "NetworkMode"
+                 "CapAdd", "CapDrop", "RestartPolicy"
          })
    public static Config create(String hostname, String domainname, String user, int memory, int memorySwap,
          int cpuShares, boolean attachStdin, boolean attachStdout, boolean attachStderr, boolean tty,
@@ -119,12 +117,12 @@ public abstract class Config {
          Map<String, ?> exposedPorts, List<String> securityOpts, HostConfig hostConfig, List<String> binds,
          List<String> links, List<Map<String, String>> lxcConf, Map<String, List<Map<String, String>>> portBindings,
          boolean publishAllPorts, boolean privileged, List<String> dns, String dnsSearch, String volumesFrom,
-         List<String> capAdd, List<String> capDrop, Map<String, String> restartPolicy, String networkMode) {
+         List<String> capAdd, List<String> capDrop, Map<String, String> restartPolicy) {
       return new AutoValue_Config(hostname, domainname, user, memory, memorySwap, cpuShares, attachStdin,
               attachStdout, attachStderr, tty, openStdin, stdinOnce, copyOf(env), copyOf(cmd), copyOf(entrypoint),
               image, copyOf(volumes), workingDir, networkDisabled, copyOf(exposedPorts), copyOf(securityOpts), hostConfig,
               copyOf(binds), copyOf(links), copyOf(lxcConf), copyOf(portBindings), publishAllPorts, privileged,
-              copyOf(dns), dnsSearch, volumesFrom, copyOf(capAdd), copyOf(capDrop), copyOf(restartPolicy), networkMode);
+              copyOf(dns), dnsSearch, volumesFrom, copyOf(capAdd), copyOf(capDrop), copyOf(restartPolicy));
    }
 
    public static Builder builder() {
@@ -170,7 +168,6 @@ public abstract class Config {
       private List<String> capAdd = Lists.newArrayList();
       private List<String> capDrop = Lists.newArrayList();
       private Map<String, String> restartPolicy = Maps.newHashMap();
-      private String networkMode;
 
       public Builder hostname(String hostname) {
          this.hostname = hostname;
@@ -348,17 +345,11 @@ public abstract class Config {
          return this;
       }
 
-      public Builder networkMode(String networkMode) {
-         this.networkMode = networkMode;
-         return this;
-      }
-
       public Config build() {
          return Config.create(hostname, domainname, user, memory, memorySwap, cpuShares, attachStdin, attachStdout,
                  attachStderr, tty, openStdin, stdinOnce, env, cmd, entrypoint, image, volumes, workingDir,
                  networkDisabled, exposedPorts, securityOpts, hostConfig, binds, links, lxcConf, portBindings,
-                 publishAllPorts, privileged, dns, dnsSearch, volumesFrom, capAdd, capDrop, restartPolicy,
-                 networkMode);
+                 publishAllPorts, privileged, dns, dnsSearch, volumesFrom, capAdd, capDrop, restartPolicy);
       }
 
       public Builder fromConfig(Config in) {
@@ -370,7 +361,7 @@ public abstract class Config {
                  .hostConfig(in.hostConfig()).binds(in.binds()).links(in.links()).lxcConf(in.lxcConf())
                  .portBindings(in.portBindings()).publishAllPorts(in.publishAllPorts()).privileged(in.privileged())
                  .dns(in.dns()).dnsSearch(in.dnsSearch()).volumesFrom(in.volumesFrom()).capAdd(in.capAdd())
-                 .capDrop(in.capDrop()).restartPolicy(in.restartPolicy()).networkMode(in.networkMode());
+                 .capDrop(in.capDrop()).restartPolicy(in.restartPolicy());
       }
 
    }

--- a/docker/src/main/java/org/jclouds/docker/domain/HostConfig.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/HostConfig.java
@@ -51,16 +51,19 @@ public abstract class HostConfig {
 
    public abstract List<String> volumesFrom();
 
+   @Nullable
+   public abstract String networkMode();
+
    HostConfig() {
    }
 
    @SerializedNames({ "ContainerIDFile", "Binds", "LxcConf", "Privileged", "Dns", "DnsSearch", "PortBindings",
-           "Links", "PublishAllPorts", "VolumesFrom" })
+         "Links", "PublishAllPorts", "VolumesFrom", "NetworkMode" })
    public static HostConfig create(String containerIDFile, List<String> binds, List<Map<String, String>> lxcConf,
          boolean privileged, List<String> dns, String dnsSearch, Map<String, List<Map<String, String>>> portBindings,
-         List<String> links, boolean publishAllPorts, List<String> volumesFrom) {
+         List<String> links, boolean publishAllPorts, List<String> volumesFrom, String networkMode) {
       return new AutoValue_HostConfig(containerIDFile, copyOf(binds), copyOf(lxcConf), privileged, copyOf(dns), dnsSearch,
-            copyOf(portBindings), copyOf(links), publishAllPorts, copyOf(volumesFrom));
+            copyOf(portBindings), copyOf(links), publishAllPorts, copyOf(volumesFrom), networkMode);
    }
 
    public static Builder builder() {
@@ -83,6 +86,7 @@ public abstract class HostConfig {
       private List<String> links = Lists.newArrayList();
       private boolean publishAllPorts;
       private List<String> volumesFrom = Lists.newArrayList();
+      private String networkMode;
 
       public Builder containerIDFile(String containerIDFile) {
          this.containerIDFile = containerIDFile;
@@ -134,15 +138,21 @@ public abstract class HostConfig {
          return this;
       }
 
+      public Builder networkMode(String networkMode) {
+         this.networkMode = networkMode;
+         return this;
+      }
+
       public HostConfig build() {
          return HostConfig.create(containerIDFile, binds, lxcConf, privileged, dns, dnsSearch, portBindings, links,
-               publishAllPorts, volumesFrom);
+               publishAllPorts, volumesFrom, networkMode);
       }
 
       public Builder fromHostConfig(HostConfig in) {
          return this.containerIDFile(in.containerIDFile()).binds(in.binds()).lxcConf(in.lxcConf())
                .privileged(in.privileged()).dns(in.dns()).dnsSearch(in.dnsSearch()).links(in.links())
-               .portBindings(in.portBindings()).publishAllPorts(in.publishAllPorts()).volumesFrom(in.volumesFrom());
+               .portBindings(in.portBindings()).publishAllPorts(in.publishAllPorts()).volumesFrom(in.volumesFrom())
+               .networkMode(in.networkMode());
       }
    }
 }

--- a/docker/src/test/java/org/jclouds/docker/compute/options/DockerTemplateOptionsTest.java
+++ b/docker/src/test/java/org/jclouds/docker/compute/options/DockerTemplateOptionsTest.java
@@ -78,6 +78,13 @@ public class DockerTemplateOptionsTest {
       assertEquals(options.as(DockerTemplateOptions.class).getPortBindings(), ImmutableMap.<Integer, Integer>builder().put(8443,  443).put(8080, 80).build());
    }
 
+
+   @Test
+   public void testNetworkMode() {
+      TemplateOptions options = DockerTemplateOptions.Builder.networkMode("host");
+      assertEquals(options.as(DockerTemplateOptions.class).getNetworkMode(), "host");
+   }
+
    @Test
    public void testNonDockerOptions() {
       TemplateOptions options = DockerTemplateOptions.Builder.userMetadata(ImmutableMap.of("key", "value")).cpuShares(1);
@@ -100,7 +107,9 @@ public class DockerTemplateOptionsTest {
             .commands("test")
             .portBindings(
                   ImmutableMap.<Integer, Integer> builder()
-                        .put(8443, 443).build()).hostname("hostname")
+                        .put(8443, 443).build())
+            .hostname("hostname")
+            .networkMode("host")
             .userMetadata(ImmutableMap.of("key", "value"))
             .env(ImmutableList.of("HOST=abc", "PORT=1234"))
             .dns("8.8.8.8", "8.8.4.4")

--- a/docker/src/test/java/org/jclouds/docker/parse/ContainerParseTest.java
+++ b/docker/src/test/java/org/jclouds/docker/parse/ContainerParseTest.java
@@ -84,6 +84,7 @@ public class ContainerParseTest extends BaseDockerParseTest<Container> {
                       )
                       .dns(ImmutableList.of("8.8.8.8", "8.8.4.4"))
                       .privileged(true)
+                      .networkMode("bridge")
                       .build())
               .driver("aufs")
               .execDriver("native-0.2")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCLOUDS-996


The `NetworkMode` attribute is located in `HostConfig` now (as defined in [Docker Remote API v 1.16](https://docs.docker.com/reference/api/docker_remote_api_v1.16/)). It's made configurable from DockerTemplateOptions.