### PR TITLE
[JCLOUDS-1006] Fix DockerUntrustedSSLContextSupplier to allow test runs without TLS

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/suppliers/DockerUntrustedSSLContextSupplier.java
+++ b/docker/src/main/java/org/jclouds/docker/suppliers/DockerUntrustedSSLContextSupplier.java
@@ -33,32 +33,33 @@ import static com.google.common.base.Throwables.propagate;
 
 @Singleton
 public class DockerUntrustedSSLContextSupplier implements Supplier<SSLContext> {
-    private final Supplier<Credentials> creds;
-    private final SSLModule.TrustAllCerts insecureTrustManager;
+   private final Supplier<Credentials> creds;
+   private final SSLModule.TrustAllCerts insecureTrustManager;
 
+   @Inject
+   DockerUntrustedSSLContextSupplier(@Provider Supplier<Credentials> creds,
+         SSLModule.TrustAllCerts insecureTrustManager) {
+      this.creds = creds;
+      this.insecureTrustManager = insecureTrustManager;
+   }
 
-    @Inject
-    DockerUntrustedSSLContextSupplier(@Provider Supplier<Credentials> creds, SSLModule.TrustAllCerts insecureTrustManager) {
-        this.creds = creds;
-        this.insecureTrustManager = insecureTrustManager;
-    }
-
-    @Override
-    public SSLContext get() {
-        Credentials currentCreds = creds.get();
-        try {
-            SSLContextBuilder builder = new SSLContextBuilder();
-            // check if identity and credential are files, to set up sslContext
-            if (currentCreds!=null && new File(currentCreds.identity).isFile() && new File(currentCreds.credential).isFile()) {
-               builder.clientKeyAndCertificate(currentCreds.credential, currentCreds.identity);
-            }
-            builder.trustManager(insecureTrustManager);
-            return builder.build();
-        } catch (GeneralSecurityException e) {
-            throw propagate(e);
-        } catch (IOException e) {
-            throw propagate(e);
-        }
-    }
+   @Override
+   public SSLContext get() {
+      Credentials currentCreds = creds.get();
+      try {
+         SSLContextBuilder builder = new SSLContextBuilder();
+         // check if identity and credential are files, to set up sslContext
+         if (currentCreds != null && new File(currentCreds.identity).isFile()
+               && new File(currentCreds.credential).isFile()) {
+            builder.clientKeyAndCertificate(currentCreds.credential, currentCreds.identity);
+         }
+         builder.trustManager(insecureTrustManager);
+         return builder.build();
+      } catch (GeneralSecurityException e) {
+         throw propagate(e);
+      } catch (IOException e) {
+         throw propagate(e);
+      }
+   }
 
 }

--- a/docker/src/main/java/org/jclouds/docker/suppliers/DockerUntrustedSSLContextSupplier.java
+++ b/docker/src/main/java/org/jclouds/docker/suppliers/DockerUntrustedSSLContextSupplier.java
@@ -24,10 +24,11 @@ import org.jclouds.location.Provider;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.net.ssl.SSLContext;
+
+import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.propagate;
 
 @Singleton
@@ -44,10 +45,13 @@ public class DockerUntrustedSSLContextSupplier implements Supplier<SSLContext> {
 
     @Override
     public SSLContext get() {
-        Credentials currentCreds = checkNotNull(creds.get(), "credential supplier returned null");
+        Credentials currentCreds = creds.get();
         try {
             SSLContextBuilder builder = new SSLContextBuilder();
-            builder.clientKeyAndCertificate(currentCreds.credential, currentCreds.identity);
+            // check if identity and credential are files, to set up sslContext
+            if (currentCreds!=null && new File(currentCreds.identity).isFile() && new File(currentCreds.credential).isFile()) {
+               builder.clientKeyAndCertificate(currentCreds.credential, currentCreds.identity);
+            }
             builder.trustManager(insecureTrustManager);
             return builder.build();
         } catch (GeneralSecurityException e) {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1006

This PR allows to use Docker endpoints without TLS configured for running live tests.

The functionality change is located in the first commit. The second one is only source code reformat to fit the jclouds coding standards.