### PR TITLE
[JCLOUDS-1011] force closing HTTP client connection after using Docker.build API

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/features/MiscApi.java
+++ b/docker/src/main/java/org/jclouds/docker/features/MiscApi.java
@@ -65,7 +65,7 @@ public interface MiscApi {
    @Named("image:build")
    @POST
    @Path("/build")
-   @Headers(keys = "Content-Type", values = "application/tar")
+   @Headers(keys = { "Content-Type", "Connection" }, values = { "application/tar", "close" })
    InputStream build(Payload inputStream);
 
    /**
@@ -79,7 +79,7 @@ public interface MiscApi {
    @Named("image:build")
    @POST
    @Path("/build")
-   @Headers(keys = "Content-Type", values = "application/tar")
+   @Headers(keys = { "Content-Type", "Connection" }, values = { "application/tar", "close" })
    InputStream build(Payload inputStream, BuildOptions options);
 
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1011

Reusing HTTP connection after calling Docker `build` REST API causes troubles in subsequent calls. We need to close the connection after the `build` call.