### PR TITLE
[JCLOUDS-1021] Add JavaDoc to cover behavior of repoTags() method in org.jclouds.docker.domain.Image

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -174,6 +174,12 @@ public class DockerComputeServiceAdapter implements
       return hardware;
    }
 
+   /**
+    * Method based on {@link org.jclouds.docker.features.ImageApi#listImages()}. It retrieves additional
+    * information by inspecting each image.
+    *
+    * @see org.jclouds.compute.ComputeServiceAdapter#listImages()
+    */
    @Override
    public Set<Image> listImages() {
       Set<Image> images = Sets.newHashSet();

--- a/docker/src/main/java/org/jclouds/docker/domain/Image.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/Image.java
@@ -26,6 +26,9 @@ import org.jclouds.json.SerializedNames;
 
 import com.google.auto.value.AutoValue;
 
+/**
+ * Represents a response from Docker "Inspect an image" call (<code>GET /images/(name)/json</code>).
+ */
 @AutoValue
 public abstract class Image {
 
@@ -55,6 +58,17 @@ public abstract class Image {
 
    public abstract long virtualSize();
 
+   /**
+    * Tags of the image. The value is <code>null</code> when the instance comes
+    * from {@link org.jclouds.docker.features.ImageApi#inspectImage(String)}.
+    * Other methods can populate the content (e.g.
+    * {@link org.jclouds.docker.compute.strategy.DockerComputeServiceAdapter#listImages()}
+    * call.
+    * <p>
+    * The tags are in form "ubuntu:12.10", "docker.io/busybox:1.23.2", ...
+    * </p>
+    * @return list of tags or <code>null</code>
+    */
    @Nullable public abstract List<String> repoTags();
 
    Image() {

--- a/docker/src/main/java/org/jclouds/docker/features/ImageApi.java
+++ b/docker/src/main/java/org/jclouds/docker/features/ImageApi.java
@@ -63,6 +63,9 @@ public interface ImageApi {
    List<ImageSummary> listImages(ListImageOptions options);
 
    /**
+    * Return low-level information on the image with given name. Not all fields from the returned {@link Image} instance
+    * are populated by this method (e.g. {@link Image#repoTags()}).
+    *
     * @param imageName The id of the image to inspect.
     * @return low-level information on the image name
     */


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1021