### PR TITLE
[JCLOUDS-1084] Docker live tests fixed and made more robust

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -38,6 +38,7 @@
     <test.docker.identity>${env.DOCKER_CERT_PATH}/cert.pem</test.docker.identity>
     <test.docker.credential>${env.DOCKER_CERT_PATH}/key.pem</test.docker.credential>
     <test.docker.cacert.path>${env.DOCKER_CERT_PATH}/ca.pem</test.docker.cacert.path>
+    <test.docker.endpoint>${env.DOCKER_HOST}</test.docker.endpoint>
     <test.jclouds.trust-all-certs>false</test.jclouds.trust-all-certs>
     <jclouds.osgi.export>org.jclouds.docker*;version="${project.version}"</jclouds.osgi.export>
     <jclouds.osgi.import>
@@ -151,7 +152,7 @@
                 </goals>
                 <configuration>
                   <name>test.docker.endpoint</name>
-                  <value>${env.DOCKER_HOST}</value>
+                  <value>${test.docker.endpoint}</value>
                   <regex>tcp</regex>
                   <replacement>https</replacement>
                   <failIfNoMatch>false</failIfNoMatch>

--- a/docker/src/test/java/org/jclouds/docker/compute/BaseDockerApiLiveTest.java
+++ b/docker/src/test/java/org/jclouds/docker/compute/BaseDockerApiLiveTest.java
@@ -33,6 +33,7 @@ import org.jclouds.Constants;
 import org.jclouds.apis.BaseApiLiveTest;
 import org.jclouds.compute.config.ComputeServiceProperties;
 import org.jclouds.docker.DockerApi;
+import org.jclouds.docker.internal.DockerTestUtils;
 import org.jclouds.io.Payload;
 import org.jclouds.io.Payloads;
 import org.jclouds.sshj.config.SshjSshClientModule;
@@ -46,12 +47,23 @@ import com.google.inject.Module;
 public class BaseDockerApiLiveTest extends BaseApiLiveTest<DockerApi> {
 
    protected static final String DEFAULT_IMAGE = "alpine";
-   protected static final String DEFAULT_TAG = "3.2";
+   protected static final String DEFAULT_TAG = "3.3";
    protected static final String ALPINE_IMAGE_TAG = String.format("%s:%s", DEFAULT_IMAGE, DEFAULT_TAG);
 
 
    public BaseDockerApiLiveTest() {
       provider = "docker";
+   }
+
+   /**
+    * Removes Docker image if it's present on the Docker host.
+    *
+    * @param imageName
+    *           image to be deleted (must be not-<code>null</code>)
+    * @see DockerTestUtils#removeImageIfExists(DockerApi, String)
+    */
+   protected void removeImageIfExists(String imageName) {
+      DockerTestUtils.removeImageIfExists(api, imageName);
    }
 
    @Override

--- a/docker/src/test/java/org/jclouds/docker/features/ContainerApiLiveTest.java
+++ b/docker/src/test/java/org/jclouds/docker/features/ContainerApiLiveTest.java
@@ -67,9 +67,6 @@ public class ContainerApiLiveTest extends BaseDockerApiLiveTest {
             api.getContainerApi().removeContainer(container.id(), RemoveContainerOptions.Builder.force(true));
          }
       }
-      if (image != null) {
-         api.getImageApi().deleteImage(ALPINE_IMAGE_TAG);
-      }
    }
 
    public void testCreateContainer() throws IOException, InterruptedException {

--- a/docker/src/test/java/org/jclouds/docker/internal/DockerTestUtils.java
+++ b/docker/src/test/java/org/jclouds/docker/internal/DockerTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.logging.Level;
+
+import org.jclouds.docker.DockerApi;
+import org.jclouds.docker.features.ImageApi;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Utility methods shared by Docker tests.
+ */
+public class DockerTestUtils {
+
+   /**
+    * Read all data from given {@link InputStream} and throw away all the bits.
+    * If an {@link IOException} occurs, it's not propagated to user. The given InputStream is closed after the read.
+    * 
+    * @param is InputStream instance (may be null)
+    */
+   public static void consumeStreamSilently(InputStream is) {
+      if (is == null) {
+         return;
+      }
+      char[] tmpBuff = new char[8 * 1024];
+      // throw everything away
+      InputStreamReader isr = new InputStreamReader(is);
+      try {
+         try {
+            while (isr.read(tmpBuff) > -1) {
+               // empty
+            }
+         } finally {
+            isr.close();
+         }
+      } catch (IOException e) {
+         java.util.logging.Logger.getAnonymousLogger().log(Level.WARNING, "Error ocured during reading InputStream.", e);
+      }
+   }
+
+   /**
+    * Removes Docker image if it's present on the Docker host. Docker Image API
+    * is used to inspect and remove image (({@link ImageApi#deleteImage(String)}
+    * method).
+    *
+    * @param dockerApi
+    *           DockerApi instance (must be not-<code>null</code>)
+    * @param imageName
+    *           image to be deleted (must be not-<code>null</code>)
+    */
+   public static void removeImageIfExists(DockerApi dockerApi, String imageName) {
+      Preconditions.checkNotNull(dockerApi, "DockerApi instance has to be provided");
+      Preconditions.checkNotNull(imageName, "Docker image name has to be provided");
+      final ImageApi imageApi = dockerApi.getImageApi();
+      if (null != imageApi.inspectImage(imageName)) {
+         consumeStreamSilently(imageApi.deleteImage(imageName));
+      }
+   }
+}

--- a/docker/src/test/resources/Dockerfile
+++ b/docker/src/test/resources/Dockerfile
@@ -16,19 +16,5 @@
 #
 
 
-FROM alpine:3.2
+FROM kwart/alpine-ext:3.3-ssh
 MAINTAINER JClouds Dev <dev@jclouds.apache.org>
-
-ENV DROPBEAR_CONF=/etc/dropbear
-
-RUN apk add --update dropbear \
-    && mkdir -p ${DROPBEAR_CONF} \
-    && dropbearkey -t dss -f ${DROPBEAR_CONF}/dropbear_dss_host_key \
-    && dropbearkey -t rsa -f ${DROPBEAR_CONF}/dropbear_rsa_host_key -s 2048 \
-    && dropbearkey -t ecdsa -f ${DROPBEAR_CONF}/dropbear_ecdsa_host_key
-
-RUN echo 'root:screencast' | chpasswd
-
-EXPOSE 22
-
-CMD ["/usr/sbin/dropbear", "-E", "-F"]


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1084

This commit fixes several issues in Docker live tests:
* `SshToCustomPortLiveTest` doesn't depend on installing additional packages (SSH server) to alpine-linux image. The image with preinstalled Dropbear and OpenSSH servers is used instead.
* `DOCKER_HOST` environment variable is not required by `pom.xml` (it's just used as a default value for `test.docker.endpoint` system property now)
* `MiscApiLiveTest` cleanup for `testBuildImageFromDockerfile` method. It removes the image created by building `Dockerfile` after the test.