### PR TITLE
[JCLOUDS-1089] Add image history support to Docker ImageApi

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/domain/ImageHistory.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/ImageHistory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.domain;
+
+import static org.jclouds.docker.internal.NullSafeCopies.copyOf;
+import java.util.List;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class ImageHistory {
+
+   public abstract String id();
+
+   public abstract long created();
+
+   public abstract String createdBy();
+
+   @Nullable public abstract List<String> tags();
+
+   public abstract long size();
+
+   public abstract String comment();
+
+
+   ImageHistory() {
+   }
+
+   @SerializedNames({"Id", "Created", "CreatedBy", "Tags", "Size", "Comment"})
+   public static ImageHistory create(String id, long created, String createdBy, List<String> tags, long size, String comment) {
+      return new AutoValue_ImageHistory(id, created, createdBy, copyOf(tags), size, comment);
+   }
+}

--- a/docker/src/main/java/org/jclouds/docker/features/ImageApi.java
+++ b/docker/src/main/java/org/jclouds/docker/features/ImageApi.java
@@ -32,6 +32,7 @@ import javax.ws.rs.core.MediaType;
 import org.jclouds.Fallbacks.EmptyListOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.docker.domain.Image;
+import org.jclouds.docker.domain.ImageHistory;
 import org.jclouds.docker.domain.ImageSummary;
 import org.jclouds.docker.options.CreateImageOptions;
 import org.jclouds.docker.options.DeleteImageOptions;
@@ -123,4 +124,16 @@ public interface ImageApi {
    @Path("/images/{name}/tag")
    void tagImage(@PathParam("name") String name, @QueryParam("repo") String repoName,
          @QueryParam("tag") String tag, @QueryParam("force") boolean force);
+
+   /**
+    * Return the history of the image with given {@code name}.
+    *
+    * @param name
+    *           the name of the image for which the history is retrieved
+    */
+   @Named("image:history")
+   @GET
+   @Path("/images/{name}/history")
+   @Fallback(EmptyListOnNotFoundOr404.class)
+   List<ImageHistory> getHistory(@PathParam("name") String name);
 }

--- a/docker/src/test/java/org/jclouds/docker/parse/HistoryParseTest.java
+++ b/docker/src/test/java/org/jclouds/docker/parse/HistoryParseTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.parse;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.docker.domain.ImageHistory;
+import org.jclouds.docker.internal.BaseDockerParseTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+@Test(groups = "unit")
+public class HistoryParseTest extends BaseDockerParseTest<List<ImageHistory>> {
+
+   @Override
+   public String resource() {
+      return "/history.json";
+   }
+
+   @Override
+   @Consumes(MediaType.APPLICATION_JSON)
+   public List<ImageHistory> expected() {
+      return ImmutableList.of(
+            ImageHistory.create("3db9c44f45209632d6050b35958829c3a2aa256d81b9a7be45b362ff85c54710",
+                  1398108230,
+                  "/bin/sh -c #(nop) ADD file:eb15dbd63394e063b805a3c32ca7bf0266ef64676d5a6fab4801f2e81e2a5148 in /",
+                  ImmutableList.of("ubuntu:lucid", "ubuntu:10.04"),
+                  182964289,
+                  ""),
+            ImageHistory.create("6cfa4d1f33fb861d4d114f43b25abd0ac737509268065cdfd69d544a59c85ab8",
+                  1398108222,
+                  "/bin/sh -c #(nop) MAINTAINER Tianon Gravi <admwiggin@gmail.com> - mkimage-debootstrap.sh -i iproute,iputils-ping,ubuntu-minimal -t lucid.tar.xz lucid http://archive.ubuntu.com/ubuntu/",
+                  null,
+                  0,
+                  ""),
+            ImageHistory.create("511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158",
+                  1371157430,
+                  "",
+                  ImmutableList.of("scratch12:latest", "scratch:latest"),
+                  0,
+                  "Imported from -")
+            );
+   }
+
+}

--- a/docker/src/test/resources/history-apiver22.json
+++ b/docker/src/test/resources/history-apiver22.json
@@ -1,0 +1,28 @@
+[
+    {
+        "Comment": "",
+        "Created": 1456304238,
+        "CreatedBy": "",
+        "Id": "sha256:fcf9d588ee9ab46c5a888e67f892fac66e6396eb195a743e50c0c5f9a4710e66",
+        "Size": 188605160,
+        "Tags": [
+            "registry.acme.com:8888/jboss-eap-test/eap-test:1.0-3"
+        ]
+    },
+    {
+        "Comment": "",
+        "Created": 1455838658,
+        "CreatedBy": "",
+        "Id": "<missing>",
+        "Size": 195019519,
+        "Tags": null
+    },
+    {
+        "Comment": "Imported from -",
+        "Created": 1455812978,
+        "CreatedBy": "",
+        "Id": "<missing>",
+        "Size": 203250948,
+        "Tags": null
+    }
+]

--- a/docker/src/test/resources/history.json
+++ b/docker/src/test/resources/history.json
@@ -1,0 +1,32 @@
+[
+    {
+        "Id": "3db9c44f45209632d6050b35958829c3a2aa256d81b9a7be45b362ff85c54710",
+        "Created": 1398108230,
+        "CreatedBy": "/bin/sh -c #(nop) ADD file:eb15dbd63394e063b805a3c32ca7bf0266ef64676d5a6fab4801f2e81e2a5148 in /",
+        "Tags": [
+            "ubuntu:lucid",
+            "ubuntu:10.04"
+        ],
+        "Size": 182964289,
+        "Comment": ""
+    },
+    {
+        "Id": "6cfa4d1f33fb861d4d114f43b25abd0ac737509268065cdfd69d544a59c85ab8",
+        "Created": 1398108222,
+        "CreatedBy": "/bin/sh -c #(nop) MAINTAINER Tianon Gravi <admwiggin@gmail.com> - mkimage-debootstrap.sh -i iproute,iputils-ping,ubuntu-minimal -t lucid.tar.xz lucid http://archive.ubuntu.com/ubuntu/",
+        "Tags": null,
+        "Size": 0,
+        "Comment": ""
+    },
+    {
+        "Id": "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158",
+        "Created": 1371157430,
+        "CreatedBy": "",
+        "Tags": [
+            "scratch12:latest",
+            "scratch:latest"
+        ],
+        "Size": 0,
+        "Comment": "Imported from -"
+    }
+]


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1089

Added support for retrieving Docker [image history](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#get-the-history-of-an-image)
