### PR TITLE
Added volumesFrom to Docker template options

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -18,6 +18,7 @@ package org.jclouds.docker.compute.strategy;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.find;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +27,14 @@ import javax.annotation.Resource;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.domain.Hardware;
@@ -47,14 +56,6 @@ import org.jclouds.docker.options.RemoveContainerOptions;
 import org.jclouds.domain.Location;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.logging.Logger;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * defines the connection between the {@link org.jclouds.docker.DockerApi} implementation and
@@ -138,7 +139,12 @@ public class DockerComputeServiceAdapter implements
             }
          }
 
+         if (!templateOptions.getVolumesFrom().isEmpty()) {
+            hostConfigBuilder.volumesFrom(templateOptions.getVolumesFrom());
+         }
+
          hostConfigBuilder.networkMode(templateOptions.getNetworkMode());
+
          containerConfigBuilder.hostConfig(hostConfigBuilder.build());
       }
 

--- a/docker/src/main/java/org/jclouds/docker/domain/Config.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/Config.java
@@ -64,7 +64,7 @@ public abstract class Config {
 
    public abstract String image();
 
-   public abstract Map<String, ?> volumes();
+   @Nullable public abstract Map<String, ?> volumes();
 
    @Nullable public abstract String workingDir();
 
@@ -76,9 +76,9 @@ public abstract class Config {
 
    @Nullable public abstract HostConfig hostConfig();
 
-   public abstract List<String> binds();
+   @Nullable public abstract List<String> binds();
 
-   public abstract List<String> links();
+   @Nullable public abstract List<String> links();
 
    public abstract List<Map<String, String>> lxcConf();
 
@@ -90,13 +90,13 @@ public abstract class Config {
 
    @Nullable public abstract List<String> dns();
 
-   @Nullable public abstract String dnsSearch();
+   @Nullable public abstract List<String> dnsSearch();
 
-   @Nullable public abstract String volumesFrom();
+   @Nullable public abstract List<String> volumesFrom();
 
-   public abstract List<String> capAdd();
+   @Nullable public abstract List<String> capAdd();
 
-   public abstract List<String> capDrop();
+   @Nullable public abstract List<String> capDrop();
 
    public abstract Map<String, String> restartPolicy();
 
@@ -117,14 +117,14 @@ public abstract class Config {
          String image, Map<String, ?> volumes, String workingDir, boolean networkDisabled,
          Map<String, ?> exposedPorts, List<String> securityOpts, HostConfig hostConfig, List<String> binds,
          List<String> links, List<Map<String, String>> lxcConf, Map<String, List<Map<String, String>>> portBindings,
-         boolean publishAllPorts, boolean privileged, List<String> dns, String dnsSearch, String volumesFrom,
+         boolean publishAllPorts, boolean privileged, List<String> dns, List<String> dnsSearch, List<String> volumesFrom,
          List<String> capAdd, List<String> capDrop, Map<String, String> restartPolicy) {
       return new AutoValue_Config(hostname, domainname, user, memory, memorySwap, cpuShares, attachStdin,
               attachStdout, attachStderr, tty, openStdin, stdinOnce, copyWithNullOf(env), copyWithNullOf(cmd),
-              copyWithNullOf(entrypoint), image, copyOf(volumes), workingDir, networkDisabled,
+              copyWithNullOf(entrypoint), image, copyWithNullOf(volumes), workingDir, networkDisabled,
               copyOf(exposedPorts), copyOf(securityOpts), hostConfig,
-              copyOf(binds), copyOf(links), copyOf(lxcConf), copyOf(portBindings), publishAllPorts, privileged,
-              copyWithNullOf(dns), dnsSearch, volumesFrom, copyOf(capAdd), copyOf(capDrop), copyOf(restartPolicy));
+              copyWithNullOf(binds), copyWithNullOf(links), copyOf(lxcConf), copyOf(portBindings), publishAllPorts, privileged,
+              copyWithNullOf(dns), copyWithNullOf(dnsSearch), copyWithNullOf(volumesFrom), copyWithNullOf(capAdd), copyWithNullOf(capDrop), copyOf(restartPolicy));
    }
 
    public static Builder builder() {
@@ -152,23 +152,23 @@ public abstract class Config {
       private List<String> cmd;
       private List<String> entrypoint;
       private String image;
-      private Map<String, ?> volumes = Maps.newHashMap();
+      private Map<String, ?> volumes;
       private String workingDir;
       private boolean networkDisabled;
       private Map<String, ?> exposedPorts = Maps.newHashMap();
       private List<String> securityOpts = Lists.newArrayList();
       private HostConfig hostConfig;
-      private List<String> binds = Lists.newArrayList();
-      private List<String> links = Lists.newArrayList();
+      private List<String> binds;
+      private List<String> links;
       private List<Map<String, String>> lxcConf = Lists.newArrayList();
       private Map<String, List<Map<String, String>>> portBindings = Maps.newHashMap();
       private boolean publishAllPorts;
       private boolean privileged;
       private List<String> dns;
-      private String dnsSearch;
-      private String volumesFrom;
-      private List<String> capAdd = Lists.newArrayList();
-      private List<String> capDrop = Lists.newArrayList();
+      private List<String> dnsSearch;
+      private List<String> volumesFrom;
+      private List<String> capAdd;
+      private List<String> capDrop;
       private Map<String, String> restartPolicy = Maps.newHashMap();
 
       public Builder hostname(String hostname) {
@@ -322,12 +322,12 @@ public abstract class Config {
          return this;
       }
 
-      public Builder dnsSearch(String dnsSearch) {
+      public Builder dnsSearch(List<String> dnsSearch) {
          this.dnsSearch = dnsSearch;
          return this;
       }
 
-      public Builder volumesFrom(String volumesFrom) {
+      public Builder volumesFrom(List<String> volumesFrom) {
          this.volumesFrom = volumesFrom;
          return this;
       }

--- a/docker/src/main/java/org/jclouds/docker/domain/HostConfig.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/HostConfig.java
@@ -16,45 +16,44 @@
  */
 package org.jclouds.docker.domain;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.docker.internal.NullSafeCopies.copyOf;
+import static org.jclouds.docker.internal.NullSafeCopies.copyWithNullOf;
 
 import java.util.List;
 import java.util.Map;
-
-import org.jclouds.javax.annotation.Nullable;
-import org.jclouds.json.SerializedNames;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
 @AutoValue
 public abstract class HostConfig {
    @Nullable public abstract String containerIDFile();
 
-   public abstract List<String> binds();
+   @Nullable public abstract List<String> binds();
 
    public abstract List<Map<String, String>> lxcConf();
 
    public abstract boolean privileged();
 
-   public abstract List<String> dns();
+   @Nullable public abstract List<String> dns();
 
    @Nullable public abstract List<String> dnsSearch();
 
    public abstract Map<String, List<Map<String, String>>> portBindings();
 
-   public abstract List<String> links();
+   @Nullable public abstract List<String> links();
 
-   public abstract List<String> extraHosts();
+   @Nullable public abstract List<String> extraHosts();
 
    public abstract boolean publishAllPorts();
 
-   public abstract List<String> volumesFrom();
+   @Nullable public abstract List<String> volumesFrom();
 
-   @Nullable
-   public abstract String networkMode();
+   @Nullable public abstract String networkMode();
 
    HostConfig() {
    }
@@ -64,8 +63,8 @@ public abstract class HostConfig {
    public static HostConfig create(String containerIDFile, List<String> binds, List<Map<String, String>> lxcConf,
          boolean privileged, List<String> dns, List<String> dnsSearch, Map<String, List<Map<String, String>>> portBindings,
          List<String> links, List<String> extraHosts, boolean publishAllPorts, List<String> volumesFrom, String networkMode) {
-      return new AutoValue_HostConfig(containerIDFile, copyOf(binds), copyOf(lxcConf), privileged, copyOf(dns), copyOf(dnsSearch),
-            copyOf(portBindings), copyOf(links), copyOf(extraHosts), publishAllPorts, copyOf(volumesFrom), networkMode);
+      return new AutoValue_HostConfig(containerIDFile, copyWithNullOf(binds), copyOf(lxcConf), privileged, copyWithNullOf(dns), copyWithNullOf(dnsSearch),
+            copyOf(portBindings), copyWithNullOf(links), copyWithNullOf(extraHosts), publishAllPorts, copyWithNullOf(volumesFrom), networkMode);
    }
 
    public static Builder builder() {
@@ -79,16 +78,16 @@ public abstract class HostConfig {
    public static final class Builder {
 
       private String containerIDFile;
-      private List<String> binds = Lists.newArrayList();
+      private List<String> binds;
       private List<Map<String, String>> lxcConf = Lists.newArrayList();
       private boolean privileged;
-      private List<String> dns = Lists.newArrayList();
-      private List<String> dnsSearch = Lists.newArrayList();
+      private List<String> dns;
+      private List<String> dnsSearch;
       private Map<String, List<Map<String, String>>> portBindings = Maps.newLinkedHashMap();
-      private List<String> links = Lists.newArrayList();
-      private List<String> extraHosts = Lists.newArrayList();
+      private List<String> links;
+      private List<String> extraHosts;
       private boolean publishAllPorts;
-      private List<String> volumesFrom = Lists.newArrayList();
+      private List<String> volumesFrom;
       private String networkMode;
 
       public Builder containerIDFile(String containerIDFile) {
@@ -97,12 +96,12 @@ public abstract class HostConfig {
       }
 
       public Builder binds(List<String> binds) {
-         this.binds.addAll(checkNotNull(binds, "binds"));
+         this.binds = binds;
          return this;
       }
 
       public Builder lxcConf(List<Map<String, String>> lxcConf) {
-         this.lxcConf.addAll(checkNotNull(lxcConf, "lxcConf"));
+         this.lxcConf = lxcConf;
          return this;
       }
 
@@ -112,27 +111,27 @@ public abstract class HostConfig {
       }
 
       public Builder dns(List<String> dns) {
-         this.dns.addAll(checkNotNull(dns, "dns"));
+         this.dns = dns;
          return this;
       }
 
       public Builder dnsSearch(List<String> dnsSearch) {
-         this.dnsSearch.addAll(checkNotNull(dnsSearch, "dnsSearch"));
+         this.dnsSearch = dnsSearch;
          return this;
       }
 
       public Builder links(List<String> links) {
-         this.links.addAll(checkNotNull(links, "links"));
+         this.links = links;
          return this;
       }
 
       public Builder extraHosts(List<String> extraHosts) {
-         this.extraHosts.addAll(checkNotNull(extraHosts, "extraHosts"));
+         this.extraHosts = extraHosts;
          return this;
       }
 
       public Builder portBindings(Map<String, List<Map<String, String>>> portBindings) {
-         this.portBindings.putAll(portBindings);
+         this.portBindings = portBindings;
          return this;
       }
 
@@ -142,7 +141,7 @@ public abstract class HostConfig {
       }
 
       public Builder volumesFrom(List<String> volumesFrom) {
-         this.volumesFrom.addAll(checkNotNull(volumesFrom, "volumesFrom"));
+         this.volumesFrom = volumesFrom;
          return this;
       }
 

--- a/docker/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
+++ b/docker/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
@@ -47,6 +47,18 @@ public class NullSafeCopies {
    }
 
    /**
+    * Copies given Map with keeping null value if provided.
+    *
+    * @param map
+    *           instance to copy (maybe <code>null</code>)
+    * @return if the parameter is not-<code>null</code> then immutable copy;
+    *         <code>null</code> otherwise
+    */
+   public static <K, V> Map<K, V> copyWithNullOf(@Nullable Map<K, V> map) {
+      return map != null ? ImmutableMap.copyOf(map) : null;
+   }
+
+   /**
     * Copies given {@link Iterable} into immutable {@link List} with keeping null value if provided.
     *
     * @param iterable

--- a/docker/src/test/java/org/jclouds/docker/compute/functions/ContainerToNodeMetadataTest.java
+++ b/docker/src/test/java/org/jclouds/docker/compute/functions/ContainerToNodeMetadataTest.java
@@ -84,7 +84,6 @@ public class ContainerToNodeMetadataTest {
               .env(null)
               .cmd(ImmutableList.of("/usr/sbin/sshd", "-D"))
               .image("jclouds/ubuntu")
-              .volumesFrom("")
               .workingDir("")
               .entrypoint(null)
               .networkDisabled(false)


### PR DESCRIPTION
Added new `volumesFrom` option to `DockerTemplateOptions` and tidies up some of the `@Nullable` entries in the configuration domain objects. Release 1.9.x version added as #253.