### PR TITLE
Make DockerTemplateOptions values null safe

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -83,15 +83,15 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    private static final String NO_IMAGE = "jclouds-placeholder-for-image";
 
    protected List<String> dns = ImmutableList.of();
-   protected String hostname;
-   protected Integer memory;
-   protected Integer cpuShares;
-   protected List<String> entrypoint = ImmutableList.of();
-   protected List<String> commands = ImmutableList.of();
+   @Nullable protected String hostname;
+   @Nullable protected Integer memory;
+   @Nullable protected Integer cpuShares;
+   @Nullable List<String> entrypoint;
+   @Nullable List<String> commands;
    protected Map<String, String> volumes = ImmutableMap.of();
-   protected List<String> env = ImmutableList.of();
+   @Nullable protected List<String> env;
    protected Map<Integer, Integer> portBindings = ImmutableMap.of();
-   protected String networkMode;
+   @Nullable protected String networkMode;
    protected Map<String, String> extraHosts = ImmutableMap.of();
    protected List<String> volumesFrom = ImmutableList.of();
    protected boolean privileged;
@@ -189,12 +189,12 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    }
 
    public DockerTemplateOptions dns(Iterable<String> dns) {
-      this.dns = NullSafeCopies.copyWithNullOf(dns);
+      this.dns = NullSafeCopies.copyOf(dns);
       return this;
    }
 
    public DockerTemplateOptions dns(String...dns) {
-      this.dns = NullSafeCopies.copyWithNullOf(dns);
+      this.dns = NullSafeCopies.copyOf(dns);
       return this;
    }
 
@@ -278,7 +278,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
     * @param extraHosts the map of host names to IP addresses
     */
    public DockerTemplateOptions extraHosts(Map<String, String> extraHosts) {
-      this.extraHosts = NullSafeCopies.copyWithNullOf(extraHosts);
+      this.extraHosts = NullSafeCopies.copyOf(extraHosts);
       return this;
    }
 
@@ -288,7 +288,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
     * @param volumesFrom the list of container names
     */
    public DockerTemplateOptions volumesFrom(Iterable<String> volumesFrom) {
-      this.volumesFrom = NullSafeCopies.copyWithNullOf(volumesFrom);
+      this.volumesFrom = NullSafeCopies.copyOf(volumesFrom);
       return this;
    }
 

--- a/docker/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
+++ b/docker/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
@@ -34,6 +34,14 @@ public class NullSafeCopies {
       return list != null ? ImmutableList.copyOf(list) : ImmutableList.<E> of();
    }
 
+   public static <E> List<E> copyOf(@Nullable Iterable<E> list) {
+      return list != null ? ImmutableList.copyOf(list) : ImmutableList.<E> of();
+   }
+
+   public static <E> List<E> copyOf(@Nullable E[] array) {
+      return array != null ? ImmutableList.copyOf(array) : ImmutableList.<E> of();
+   }
+
    /**
     * Copies given List with keeping null value if provided.
     *


### PR DESCRIPTION
Do not reset `entrypoint` or `commands` options to an empty list, which overrides any Dockerfile provided values.