### PR TITLE
JCLOUDS-1041: Fix NPE when deserializing Port in Docker 1.9.1

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/domain/Port.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/Port.java
@@ -16,17 +16,18 @@
  */
 package org.jclouds.docker.domain;
 
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
 import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class Port {
-   public abstract String ip();
+   @Nullable public abstract String ip();
 
    public abstract int privatePort();
 
-   public abstract int publicPort();
+   @Nullable public abstract Integer publicPort();
 
    public abstract String type();
 
@@ -34,7 +35,7 @@ public abstract class Port {
    }
 
    @SerializedNames({ "IP", "PrivatePort", "PublicPort", "Type" })
-   public static Port create(String ip, int privatePort, int publicPort, String type) {
+   public static Port create(String ip, int privatePort, Integer publicPort, String type) {
       return new AutoValue_Port(ip, privatePort, publicPort, type);
    }
 }

--- a/docker/src/test/java/org/jclouds/docker/parse/ContainersParseTest.java
+++ b/docker/src/test/java/org/jclouds/docker/parse/ContainersParseTest.java
@@ -39,15 +39,13 @@ public class ContainersParseTest extends BaseDockerParseTest<List<ContainerSumma
    @Override
    @Consumes(MediaType.APPLICATION_JSON)
    public List<ContainerSummary> expected() {
-      return ImmutableList.of(
-              ContainerSummary.create("6d35806c1bd2b25cd92bba2d2c2c5169dc2156f53ab45c2b62d76e2d2fee14a9",
-                      ImmutableList.of("/hopeful_mclean"),
-                      "1395472605",
-                      "jclouds/ubuntu:latest",
-                      "/usr/sbin/sshd -D",
-                      ImmutableList.of(Port.create("0.0.0.0", 22, 49231, "tcp")),
-                      "Up 55 seconds")
-      );
+      return ImmutableList.of(ContainerSummary.create(
+            "6d35806c1bd2b25cd92bba2d2c2c5169dc2156f53ab45c2b62d76e2d2fee14a9", ImmutableList.of("/hopeful_mclean"),
+            "1395472605", "jclouds/ubuntu:latest", "/usr/sbin/sshd -D",
+            ImmutableList.of(Port.create("0.0.0.0", 22, 49231, "tcp")), "Up 55 seconds"), ContainerSummary.create(
+            "6d35806c1bd2b25cd92bba2d2c2c5169dc2156f53ab45c2b62d76e2d2fee14a2", ImmutableList.of("/hopeful_mclean"),
+            "1395472605", "jclouds/ubuntu:latest", "/usr/sbin/sshd -D",
+            ImmutableList.of(Port.create(null, 22, null, "tcp")), "Up 55 seconds"));
    }
 
 }

--- a/docker/src/test/resources/containers.json
+++ b/docker/src/test/resources/containers.json
@@ -16,5 +16,21 @@
       }
     ],
     "Status": "Up 55 seconds"
+  },
+  {
+    "Command": "/usr/sbin/sshd -D",
+    "Created": 1395472605,
+    "Id": "6d35806c1bd2b25cd92bba2d2c2c5169dc2156f53ab45c2b62d76e2d2fee14a2",
+    "Image": "jclouds/ubuntu:latest",
+    "Names": [
+      "/hopeful_mclean"
+    ],
+    "Ports": [
+      {
+        "PrivatePort": 22,
+        "Type": "tcp"
+      }
+    ],
+    "Status": "Up 55 seconds"
   }
 ]


### PR DESCRIPTION
This backports this change (46aec3aa2bdb362d7ba9a17cb1c3c9b0509b30ef) from 2.0.0 to 1.9.x.  Needed to fix issue where ip is null in json returned from Docker REST API.