### PR TITLE
docker container ips: cherry-pick PR #284

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/domain/NetworkSettings.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/NetworkSettings.java
@@ -16,39 +16,132 @@
  */
 package org.jclouds.docker.domain;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.docker.internal.NullSafeCopies.copyOf;
 
 import java.util.List;
 import java.util.Map;
 
+import org.jclouds.docker.internal.NullSafeCopies;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 @AutoValue
 public abstract class NetworkSettings {
+
+   @AutoValue
+   public abstract static class Details {
+
+      Details() {} // For AutoValue only!
+
+      public abstract String endpoint();
+
+      public abstract String gateway();
+
+      public abstract String ipAddress();
+
+      public abstract int ipPrefixLen();
+
+      public abstract String ipv6Gateway();
+
+      public abstract String globalIPv6Address();
+
+      public abstract int globalIPv6PrefixLen();
+
+      public abstract String macAddress();
+
+      @SerializedNames({ "EndpointID", "Gateway", "IPAddress", "IPPrefixLen", "IPv6Gateway", "GlobalIPv6Address", "GlobalIPv6PrefixLen", "MacAddress" })
+      public static Details create(String endpointId, String gateway, String ipAddress, int ipPrefixLen, String ipv6Gateway, String globalIPv6Address,
+                                   int globalIPv6PrefixLen, String macAddress) {
+         return builder().endpoint(endpointId).gateway(gateway).ipAddress(ipAddress).ipPrefixLen(ipPrefixLen)
+               .ipv6Gateway(ipv6Gateway).globalIPv6Address(globalIPv6Address)
+               .globalIPv6PrefixLen(globalIPv6PrefixLen).macAddress(macAddress)
+               .build();
+      }
+      
+      public Builder toBuilder() {
+         return new AutoValue_NetworkSettings_Details.Builder(this);
+      }
+
+      public static Builder builder() {
+         return new AutoValue_NetworkSettings_Details.Builder();
+      }
+
+      @AutoValue.Builder
+      public abstract static class Builder {
+         public abstract Builder endpoint(String value);
+         public abstract Builder gateway(String value);
+         public abstract Builder ipAddress(String value);
+         public abstract Builder ipPrefixLen(int value);
+         public abstract Builder ipv6Gateway(String value);
+         public abstract Builder globalIPv6Address(String value);
+         public abstract Builder globalIPv6PrefixLen(int value);
+         public abstract Builder macAddress(String value);
+
+         public abstract Details build();
+      }
+   }
+
+   public abstract String bridge();
+
+   @Nullable public abstract String sandboxId();
+
+   public abstract boolean hairpinMode();
+
+   @Nullable public abstract String linkLocalIPv6Address();
+
+   public abstract int linkLocalIPv6PrefixLen();
+
+   @Nullable public abstract Map<String, List<Map<String, String>>> ports();
+
+   @Nullable public abstract String sandboxKey();
+
+   public abstract List<String> secondaryIPAddresses();
+
+   public abstract List<String> secondaryIPv6Addresses();
+
+   @Nullable public abstract String endpointId();
+
+   public abstract String gateway();
+
+   @Nullable public abstract String globalIPv6Address();
+
+   public abstract int globalIPv6PrefixLen();
+
    public abstract String ipAddress();
 
    public abstract int ipPrefixLen();
 
-   public abstract String gateway();
+   @Nullable public abstract String ipv6Gateway();
 
-   public abstract String bridge();
+   @Nullable public abstract String macAddress();
+
+   public abstract Map<String, Details> networks();
 
    @Nullable public abstract String portMapping();
-
-   public abstract Map<String, List<Map<String, String>>> ports();
 
    NetworkSettings() {
    }
 
-   @SerializedNames({ "IPAddress", "IPPrefixLen", "Gateway", "Bridge", "PortMapping", "Ports" })
-   public static NetworkSettings create(String ipAddress, int ipPrefixLen, String gateway, String bridge,
-         String portMapping, Map<String, List<Map<String, String>>> ports) {
-      return new AutoValue_NetworkSettings(ipAddress, ipPrefixLen, gateway, bridge, portMapping, copyOf(ports));
+   @SerializedNames({ "Bridge", "SandboxID", "HairpinMode", "LinkLocalIPv6Address",
+           "LinkLocalIPv6PrefixLen", "Ports", "SandboxKey", "SecondaryIPAddresses",
+           "SecondaryIPv6Addresses", "EndpointID", "Gateway", "GlobalIPv6Address",
+           "GlobalIPv6PrefixLen", "IPAddress", "IPPrefixLen", "IPv6Gateway",
+           "MacAddress", "Networks", "PortMapping" })
+   public static NetworkSettings create(String bridge, String sandboxId, boolean hairpinMode, String linkLocalIPv6Address,
+                                        int linkLocalIPv6PrefixLen, Map<String, List<Map<String, String>>> ports, String sandboxKey, List<String> secondaryIPAddresses,
+                                        List<String> secondaryIPv6Addresses, String endpointId, String gateway, String globalIPv6Address,
+                                        int globalIPv6PrefixLen, String ipAddress, int ipPrefixLen, String ipv6Gateway,
+                                        String macAddress, Map<String, Details> networks, String portMapping) {
+      return new AutoValue_NetworkSettings(
+              bridge, sandboxId, hairpinMode, linkLocalIPv6Address,
+              linkLocalIPv6PrefixLen, ports, sandboxKey, copyOf(secondaryIPAddresses), copyOf(secondaryIPv6Addresses),
+              endpointId, gateway, globalIPv6Address, globalIPv6PrefixLen,
+              ipAddress, ipPrefixLen, ipv6Gateway,
+              macAddress, copyOf(networks), portMapping);
    }
 
    public static Builder builder() {
@@ -66,7 +159,20 @@ public abstract class NetworkSettings {
       private String gateway;
       private String bridge;
       private String portMapping;
-      private Map<String, List<Map<String, String>>> ports = ImmutableMap.of();
+      private Map<String, List<Map<String, String>>> ports;
+      private String sandboxId;
+      private boolean hairpinMode;
+      private String linkLocalIPv6Address;
+      private int linkLocalIPv6PrefixLen;
+      private String sandboxKey;
+      private List<String> secondaryIPAddresses = Lists.newArrayList();
+      private List<String> secondaryIPv6Addresses = Lists.newArrayList();
+      private String endpointId;
+      private String globalIPv6Address;
+      private int globalIPv6PrefixLen;
+      private String ipv6Gateway;
+      private String macAddress;
+      private Map<String, Details> networks = Maps.newHashMap();
 
       public Builder ipAddress(String ipAddress) {
          this.ipAddress = ipAddress;
@@ -94,17 +200,88 @@ public abstract class NetworkSettings {
       }
 
       public Builder ports(Map<String, List<Map<String, String>>> ports) {
-         this.ports = ImmutableMap.copyOf(checkNotNull(ports, "ports"));
+         this.ports = NullSafeCopies.copyWithNullOf(ports);
+         return this;
+      }
+
+      public Builder sandboxId(String sandboxId) {
+         this.sandboxId = sandboxId;
+         return this;
+      }
+
+      public Builder hairpinMode(boolean hairpinMode) {
+         this.hairpinMode = hairpinMode;
+         return this;
+      }
+
+      public Builder linkLocalIPv6Address(String linkLocalIPv6Address) {
+         this.linkLocalIPv6Address = linkLocalIPv6Address;
+         return this;
+      }
+
+      public Builder linkLocalIPv6PrefixLen(int linkLocalIPv6PrefixLen) {
+         this.linkLocalIPv6PrefixLen = linkLocalIPv6PrefixLen;
+         return this;
+      }
+
+      public Builder sandboxKey(String sandboxKey) {
+         this.sandboxKey = sandboxKey;
+         return this;
+      }
+
+      public Builder secondaryIPAddresses(List<String> secondaryIPAddresses) {
+         this.secondaryIPAddresses = secondaryIPAddresses;
+         return this;
+      }
+
+      public Builder secondaryIPv6Addresses(List<String> secondaryIPv6Addresses) {
+         this.secondaryIPv6Addresses = secondaryIPv6Addresses;
+         return this;
+      }
+
+      public Builder endpointId(String endpointId) {
+         this.endpointId = endpointId;
+         return this;
+      }
+
+      public Builder globalIPv6Address(String globalIPv6Address) {
+         this.globalIPv6Address = globalIPv6Address;
+         return this;
+      }
+
+      public Builder globalIPv6PrefixLen(int globalIPv6PrefixLen) {
+         this.globalIPv6PrefixLen = globalIPv6PrefixLen;
+         return this;
+      }
+
+      public Builder ipv6Gateway(String ipv6Gateway) {
+         this.ipv6Gateway = ipv6Gateway;
+         return this;
+      }
+
+      public Builder macAddress(String macAddress) {
+         this.macAddress = macAddress;
+         return this;
+      }
+
+      public Builder networks(Map<String, Details> networks) {
+         this.networks.putAll(networks);
          return this;
       }
 
       public NetworkSettings build() {
-         return NetworkSettings.create(ipAddress, ipPrefixLen, gateway, bridge, portMapping, ports);
+         return NetworkSettings.create(bridge, sandboxId, hairpinMode, linkLocalIPv6Address, linkLocalIPv6PrefixLen, ports,
+                 sandboxKey, secondaryIPAddresses, secondaryIPv6Addresses, endpointId, gateway,
+                 globalIPv6Address, globalIPv6PrefixLen, ipAddress, ipPrefixLen, ipv6Gateway, macAddress, networks, portMapping);
       }
 
       public Builder fromNetworkSettings(NetworkSettings in) {
          return this.ipAddress(in.ipAddress()).ipPrefixLen(in.ipPrefixLen()).gateway(in.gateway()).bridge(in.bridge())
-               .portMapping(in.portMapping()).ports(in.ports());
+               .portMapping(in.portMapping()).ports(in.ports()).sandboxId(in.sandboxId()).hairpinMode(in.hairpinMode()).linkLocalIPv6Address(in
+                         .linkLocalIPv6Address()).linkLocalIPv6PrefixLen(in.linkLocalIPv6PrefixLen()).sandboxKey(in.sandboxKey()).secondaryIPAddresses(in
+                         .secondaryIPAddresses()).secondaryIPv6Addresses(in.secondaryIPv6Addresses()).endpointId(in.endpointId()).globalIPv6Address(in
+                         .globalIPv6Address()).globalIPv6PrefixLen(in.globalIPv6PrefixLen()).ipv6Gateway(in.ipv6Gateway()).macAddress(in.macAddress())
+                 .networks(in.networks());
       }
    }
 

--- a/docker/src/test/java/org/jclouds/docker/config/DockerParserModuleTest.java
+++ b/docker/src/test/java/org/jclouds/docker/config/DockerParserModuleTest.java
@@ -19,6 +19,9 @@ package org.jclouds.docker.config;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import java.util.List;
+import java.util.Map;
+
 import org.jclouds.docker.domain.Container;
 import org.jclouds.docker.domain.NetworkSettings;
 import org.jclouds.docker.domain.Port;
@@ -53,8 +56,70 @@ public class DockerParserModuleTest {
    }
 
    public void networkSettings() {
-      String text = "{\"IPAddress\":\"XX.XX.206.98\",\"IPPrefixLen\":27,\"Gateway\":\"XX.XX.206.105\",\"Bridge\":\"public\",\"Ports\":{}}";
-      NetworkSettings settings = NetworkSettings.create("XX.XX.206.98", 27, "XX.XX.206.105", "public", null, null);
+      String text = "{" +
+              "\"Bridge\":\"\"," +
+              "\"SandboxID\":\"3ef128b055eb9ef62a6a2c281d97a2dfde5f47947d490f1dd2a81612611d961f\"," +
+              "\"HairpinMode\":false," +
+              "\"LinkLocalIPv6Address\":\"\"," +
+              "\"LinkLocalIPv6PrefixLen\":0," +
+              "\"Ports\":{}," +
+              "\"SandboxKey\":\"/var/run/docker/netns/3ef128b055eb\"," +
+              "\"SecondaryIPAddresses\":[]," +
+              "\"SecondaryIPv6Addresses\":[]," +
+              "\"EndpointID\":\"9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6\"," +
+              "\"Gateway\":\"172.17.0.1\"," +
+              "\"GlobalIPv6Address\":\"\"," +
+              "\"GlobalIPv6PrefixLen\":0," +
+              "\"IPAddress\":\"172.17.0.2\"," +
+              "\"IPPrefixLen\":16," +
+              "\"IPv6Gateway\":\"\"," +
+              "\"MacAddress\":\"02:42:ac:11:00:02\"," +
+              "\"Networks\":{" +
+              "\"bridge\":{" +
+              "\"EndpointID\":\"9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6\"," +
+              "\"Gateway\":\"172.17.0.1\"," +
+              "\"IPAddress\":\"172.17.0.2\"," +
+              "\"IPPrefixLen\":16," +
+              "\"IPv6Gateway\":\"\"," +
+              "\"GlobalIPv6Address\":\"\"," +
+              "\"GlobalIPv6PrefixLen\":0," +
+              "\"MacAddress\":\"02:42:ac:11:00:02\"" +
+              "}" +
+              "}" +
+              "}";
+      NetworkSettings settings = NetworkSettings.create(
+              "", // Bridge
+              "3ef128b055eb9ef62a6a2c281d97a2dfde5f47947d490f1dd2a81612611d961f", // SandboxID
+              false, // HairpinMode
+              "", // LinkLocalIPv6Address
+              0, // LinkLocalIPv6PrefixLen
+              ImmutableMap.<String, List<Map<String, String>>> of(), // Ports
+              "/var/run/docker/netns/3ef128b055eb", // SandboxKey
+              null, // SecondaryIPAddresses
+              null, // SecondaryIPv6Addresses
+              "9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6", // EndpointID
+              "172.17.0.1", // Gateway
+              "", // GlobalIPv6Address
+              0, // GlobalIPv6PrefixLen
+              "172.17.0.2", // IPAddress
+              16, // IPPrefixLen
+              "", // IPv6Gateway
+              "02:42:ac:11:00:02", // MacAddress
+              ImmutableMap.of(
+                      "bridge", NetworkSettings.Details.create(
+                              "9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6", // EndpointID
+                              "172.17.0.1", // Gateway
+                              "172.17.0.2", // IPAddress
+                              16, // IPPrefixLen
+                              "", // IPv6Gateway
+                              "", // GlobalIPv6Address
+                              0, // GlobalIPv6PrefixLen
+                              "02:42:ac:11:00:02" // MacAddress
+                     )
+              ),
+              null // PortMapping
+      );
+
       assertEquals(json.fromJson(text, NetworkSettings.class), settings);
       assertEquals(json.toJson(settings), text);
    }

--- a/docker/src/test/java/org/jclouds/docker/parse/ContainerParseTest.java
+++ b/docker/src/test/java/org/jclouds/docker/parse/ContainerParseTest.java
@@ -55,26 +55,54 @@ public class ContainerParseTest extends BaseDockerParseTest<Container> {
               .config(Config.builder()
                       .hostname("6c9932f478bd")
                       .env(ImmutableList.of("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"))
-                      .image("57e570db16baba1e8c0d6f3c15868ddb400f64ff76ec948e65c3ca3f15fb3587")
+                      .image("zettio/weave")
                       .domainname("")
                       .user("")
                       .cmd(ImmutableList.of("-name", "7a:63:a2:39:7b:0f"))
                       .entrypoint(ImmutableList.of("/home/weave/weaver", "-iface", "ethwe", "-wait", "5"))
-                      .image("zettio/weave")
                       .workingDir("/home/weave")
                       .exposedPorts(ImmutableMap.of("6783/tcp", ImmutableMap.of(), "6783/udp", ImmutableMap.of()))
                       .build())
-              .state(State.create(3939, true, 0, "2014-10-31T17:00:21.802008706Z", "0001-01-01T00:00:00Z", false, false))
+              .state(State.create(10357, true, 0, "2015-11-10T09:33:21.68146124Z", "0001-01-01T00:00:00Z", false, false))
               .image("57e570db16baba1e8c0d6f3c15868ddb400f64ff76ec948e65c3ca3f15fb3587")
               .networkSettings(NetworkSettings.builder()
-                      .ipAddress("172.17.0.7")
+                      .sandboxId("3ef128b055eb9ef62a6a2c281d97a2dfde5f47947d490f1dd2a81612611d961f")
+                      .hairpinMode(false)
+                      .linkLocalIPv6Address("")
+                      .linkLocalIPv6PrefixLen(0)
+                      .globalIPv6Address("")
+                      .globalIPv6PrefixLen(0)
+                      .ipv6Gateway("")
+                      .sandboxKey("/var/run/docker/netns/3ef128b055eb")
+                      .endpointId("9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6")
+                      .ipAddress("172.17.0.2")
                       .ipPrefixLen(16)
-                      .gateway("172.17.42.1")
-                      .bridge("docker0")
-                      .ports(ImmutableMap.<String, List<Map<String, String>>>of(
-                                      "6783/tcp", ImmutableList.<Map<String, String>>of(ImmutableMap.of("HostIp", "0.0.0.0", "HostPort", "6783")),
-                                      "6783/udp", ImmutableList.<Map<String, String>>of(ImmutableMap.of("HostIp", "0.0.0.0", "HostPort", "6783")))
-                      )
+                      .gateway("172.17.0.1")
+                      .bridge("")
+                      .ports(ImmutableMap.<String, List<Map<String, String>>>of())
+                      .macAddress("02:42:ac:11:00:02")
+                      .networks(ImmutableMap.of(
+                              "JCLOUDS_NETWORK", NetworkSettings.Details.create(
+                                      "04268fbb4dc368b5a53bb1c3f89294a4f0c72095deb944db3c4efc6d6a439304",
+                                      "172.19.0.1",
+                                      "172.19.0.2",
+                                      16,
+                                      "",
+                                      "",
+                                      0,
+                                      "02:42:ac:13:00:02"
+                              ),
+                              "bridge", NetworkSettings.Details.create(
+                                      "9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6",
+                                      "172.17.0.1",
+                                      "172.17.0.2",
+                                      16,
+                                      "",
+                                      "",
+                                      0,
+                                      "02:42:ac:11:00:02"
+                              )
+                      ))
                       .build())
               .resolvConfPath("/var/lib/docker/containers/6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524/resolv.conf")
               .hostConfig(HostConfig.builder()

--- a/docker/src/test/resources/container.json
+++ b/docker/src/test/resources/container.json
@@ -1,132 +1,184 @@
+// 20160613195536
+// https://raw.githubusercontent.com/jclouds/jclouds-labs/master/docker/src/test/resources/container.json
+
 {
-    "Args": [
-        "-iface",
-        "ethwe",
-        "-wait",
-        "5",
-        "-name",
-        "7a:63:a2:39:7b:0f"
+  "Args": [
+    "-iface",
+    "ethwe",
+    "-wait",
+    "5",
+    "-name",
+    "7a:63:a2:39:7b:0f"
+  ],
+  "Config": {
+    "AttachStderr": false,
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "Cmd": [
+      "-name",
+      "7a:63:a2:39:7b:0f"
     ],
-    "Config": {
-        "AttachStderr": false,
-        "AttachStdin": false,
-        "AttachStdout": false,
-        "Cmd": [
-            "-name",
-            "7a:63:a2:39:7b:0f"
-        ],
-        "CpuShares": 0,
-        "Cpuset": "",
-        "Domainname": "",
-        "Entrypoint": [
-            "/home/weave/weaver",
-            "-iface",
-            "ethwe",
-            "-wait",
-            "5"
-        ],
-        "Env": [
-            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        ],
-        "ExposedPorts": {
-            "6783/tcp": {},
-            "6783/udp": {}
-        },
-        "Hostname": "6c9932f478bd",
-        "Image": "zettio/weave",
-        "Memory": 0,
-        "MemorySwap": 0,
-        "NetworkDisabled": false,
-        "OnBuild": null,
-        "OpenStdin": false,
-        "PortSpecs": null,
-        "SecurityOpt": null,
-        "StdinOnce": false,
-        "Tty": false,
-        "User": "",
-        "Volumes": null,
-        "WorkingDir": "/home/weave"
+    "CpuShares": 0,
+    "Cpuset": "",
+    "Domainname": "",
+    "Entrypoint": [
+      "/home/weave/weaver",
+      "-iface",
+      "ethwe",
+      "-wait",
+      "5"
+    ],
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ],
+    "ExposedPorts": {
+      "6783/tcp": {
+        
+      },
+      "6783/udp": {
+        
+      }
     },
-    "Created": "2014-10-31T17:00:21.544197943Z",
-    "Driver": "aufs",
-    "ExecDriver": "native-0.2",
-    "HostConfig": {
-        "Binds": null,
-        "CapAdd": null,
-        "CapDrop": null,
-        "ContainerIDFile": "",
-        "Devices": [],
-        "Dns": [ "8.8.8.8", "8.8.4.4" ],
-        "DnsSearch": null,
-        "ExtraHosts": [ "extra:169.254.0.1" ],
-        "Links": null,
-        "LxcConf": [],
-        "NetworkMode": "bridge",
-        "PortBindings": {
-            "6783/tcp": [
-                {
-                    "HostIp": "",
-                    "HostPort": "6783"
-                }
-            ],
-            "6783/udp": [
-                {
-                    "HostIp": "",
-                    "HostPort": "6783"
-                }
-            ]
-        },
-        "Privileged": true,
-        "PublishAllPorts": false,
-        "RestartPolicy": {
-            "MaximumRetryCount": 0,
-            "Name": ""
-        },
-        "VolumesFrom": null
-    },
-    "HostnamePath": "/var/lib/docker/containers/6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524/hostname",
-    "HostsPath": "/var/lib/docker/containers/6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524/hosts",
-    "Id": "6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524",
-    "Image": "57e570db16baba1e8c0d6f3c15868ddb400f64ff76ec948e65c3ca3f15fb3587",
-    "MountLabel": "",
-    "Name": "/weave",
-    "NetworkSettings": {
-        "Bridge": "docker0",
-        "Gateway": "172.17.42.1",
-        "IPAddress": "172.17.0.7",
-        "IPPrefixLen": 16,
-        "MacAddress": "02:42:ac:11:00:07",
-        "PortMapping": null,
-        "Ports": {
-            "6783/tcp": [
-                {
-                    "HostIp": "0.0.0.0",
-                    "HostPort": "6783"
-                }
-            ],
-            "6783/udp": [
-                {
-                    "HostIp": "0.0.0.0",
-                    "HostPort": "6783"
-                }
-            ]
+    "Hostname": "6c9932f478bd",
+    "Image": "zettio/weave",
+    "Memory": 0,
+    "MemorySwap": 0,
+    "NetworkDisabled": false,
+    "OnBuild": null,
+    "OpenStdin": false,
+    "PortSpecs": null,
+    "SecurityOpts": null,
+    "StdinOnce": false,
+    "Tty": false,
+    "User": "",
+    "Volumes": null,
+    "WorkingDir": "/home/weave"
+  },
+  "Created": "2014-10-31T17:00:21.544197943Z",
+  "Driver": "aufs",
+  "ExecDriver": "native-0.2",
+  "HostConfig": {
+    "Binds": null,
+    "CapAdd": [
+      "NET_ADMIN"
+    ],
+    "CapDrop": [
+      "MKNOD"
+    ],
+    "ContainerIDFile": "",
+    "Devices": [
+      
+    ],
+    "Dns": [
+      "8.8.8.8",
+      "8.8.4.4"
+    ],
+    "DnsSearch": null,
+    "ExtraHosts": [
+      "extra:169.254.0.1"
+    ],
+    "Links": null,
+    "LxcConf": [
+      
+    ],
+    "NetworkMode": "bridge",
+    "PortBindings": {
+      "6783/tcp": [
+        {
+          "HostIp": "",
+          "HostPort": "6783"
         }
+      ],
+      "6783/udp": [
+        {
+          "HostIp": "",
+          "HostPort": "6783"
+        }
+      ]
     },
-    "Node": {
-        "IP": "10.10.10.10"
+    "Privileged": true,
+    "PublishAllPorts": false,
+    "RestartPolicy": {
+      "MaximumRetryCount": 0,
+      "Name": ""
     },
-    "Path": "/home/weave/weaver",
-    "ProcessLabel": "",
-    "ResolvConfPath": "/var/lib/docker/containers/6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524/resolv.conf",
-    "State": {
-        "ExitCode": 0,
-        "FinishedAt": "0001-01-01T00:00:00Z",
-        "Paused": false,
-        "Pid": 3939,
-        "Restarting": false,
-        "Running": true,
-        "StartedAt": "2014-10-31T17:00:21.802008706Z"
+    "VolumesFrom": null
+  },
+  "HostnamePath": "/var/lib/docker/containers/6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524/hostname",
+  "HostsPath": "/var/lib/docker/containers/6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524/hosts",
+  "Id": "6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524",
+  "Image": "57e570db16baba1e8c0d6f3c15868ddb400f64ff76ec948e65c3ca3f15fb3587",
+  "MountLabel": "",
+  "Name": "/weave",
+  "NetworkSettings": {
+    "Bridge": "",
+    "SandboxID": "3ef128b055eb9ef62a6a2c281d97a2dfde5f47947d490f1dd2a81612611d961f",
+    "HairpinMode": false,
+    "LinkLocalIPv6Address": "",
+    "LinkLocalIPv6PrefixLen": 0,
+    "Ports": {
+      
     },
-    "Volumes": {},
-    "VolumesRW": {}
+    "SandboxKey": "/var/run/docker/netns/3ef128b055eb",
+    "SecondaryIPAddresses": null,
+    "SecondaryIPv6Addresses": null,
+    "EndpointID": "9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6",
+    "Gateway": "172.17.0.1",
+    "GlobalIPv6Address": "",
+    "GlobalIPv6PrefixLen": 0,
+    "IPAddress": "172.17.0.2",
+    "IPPrefixLen": 16,
+    "IPv6Gateway": "",
+    "MacAddress": "02:42:ac:11:00:02",
+    "Networks": {
+      "JCLOUDS_NETWORK": {
+        "EndpointID": "04268fbb4dc368b5a53bb1c3f89294a4f0c72095deb944db3c4efc6d6a439304",
+        "Gateway": "172.19.0.1",
+        "IPAddress": "172.19.0.2",
+        "IPPrefixLen": 16,
+        "IPv6Gateway": "",
+        "GlobalIPv6Address": "",
+        "GlobalIPv6PrefixLen": 0,
+        "MacAddress": "02:42:ac:13:00:02"
+      },
+      "bridge": {
+        "EndpointID": "9e8dcc0c8288938a923018fee0728cee8e6de7c01a5150738ee6e51c1caf8cf6",
+        "Gateway": "172.17.0.1",
+        "IPAddress": "172.17.0.2",
+        "IPPrefixLen": 16,
+        "IPv6Gateway": "",
+        "GlobalIPv6Address": "",
+        "GlobalIPv6PrefixLen": 0,
+        "MacAddress": "02:42:ac:11:00:02"
+      }
+    }
+  },
+  "Node": {
+    "IP": "10.10.10.10"
+  },
+  "Path": "/home/weave/weaver",
+  "ProcessLabel": "",
+  "ResolvConfPath": "/var/lib/docker/containers/6c9932f478bd761f32ddb54ed28ab42ab6fac6f2a279f561ea31503ee9d39524/resolv.conf",
+  "SecurityOpt": [
+    
+  ],
+  "State": {
+    "Status": "running",
+    "Running": true,
+    "Paused": false,
+    "Restarting": false,
+    "OOMKilled": false,
+    "Dead": false,
+    "Pid": 10357,
+    "ExitCode": 0,
+    "Error": "",
+    "StartedAt": "2015-11-10T09:33:21.68146124Z",
+    "FinishedAt": "0001-01-01T00:00:00Z"
+  },
+  "Volumes": {
+    
+  },
+  "VolumesRW": {
+    
+  }
 }


### PR DESCRIPTION
* Copies latest NetworkSettings from master - to get networks()
* Copies ContainerToNodeMetadata.getPrivateIpAddresses() - to get IPs from networks as well.
* Copies ContainerParseTest, and an updated container.json (which tests networkSettings.networks)
* Copies ContainerToNodeMetadataTest (which tests IPs from private networks)