### PR TITLE
Docker ImageId can be image name or id and will pull from hub

### DIFF
--- a/docker/src/test/java/org/jclouds/docker/compute/DockerComputeServiceAdapterLiveTest.java
+++ b/docker/src/test/java/org/jclouds/docker/compute/DockerComputeServiceAdapterLiveTest.java
@@ -19,9 +19,17 @@ package org.jclouds.docker.compute;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import java.util.Properties;
 import java.util.Random;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.inject.Injector;
+import com.google.inject.Module;
 
 import org.jclouds.compute.ComputeServiceAdapter.NodeAndInitialCredentials;
 import org.jclouds.compute.domain.Hardware;
@@ -32,17 +40,10 @@ import org.jclouds.docker.compute.options.DockerTemplateOptions;
 import org.jclouds.docker.compute.strategy.DockerComputeServiceAdapter;
 import org.jclouds.docker.domain.Container;
 import org.jclouds.docker.domain.Image;
-import org.jclouds.docker.options.CreateImageOptions;
 import org.jclouds.sshj.config.SshjSshClientModule;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.inject.Injector;
-import com.google.inject.Module;
 
 @Test(groups = "live", singleThreaded = true, testName = "DockerComputeServiceAdapterLiveTest")
 public class DockerComputeServiceAdapterLiveTest extends BaseDockerApiLiveTest {
@@ -54,17 +55,13 @@ public class DockerComputeServiceAdapterLiveTest extends BaseDockerApiLiveTest {
    private DockerComputeServiceAdapter adapter;
    private TemplateBuilder templateBuilder;
    private NodeAndInitialCredentials<Container> guest;
+   private static final String CHUANWEN_COWSAY = "chuanwen/cowsay";
 
    @BeforeClass
    protected void init() {
       super.initialize();
       String imageName = SSHABLE_IMAGE + ":" + SSHABLE_IMAGE_TAG;
-      Image image = api.getImageApi().inspectImage(imageName);
-      if (image == null) {
-         CreateImageOptions options = CreateImageOptions.Builder.fromImage(SSHABLE_IMAGE).tag(SSHABLE_IMAGE_TAG);
-         api.getImageApi().createImage(options);
-      }
-      defaultImage = api.getImageApi().inspectImage(imageName);
+      defaultImage = adapter.getImage(imageName);
       assertNotNull(defaultImage);
    }
 
@@ -72,6 +69,9 @@ public class DockerComputeServiceAdapterLiveTest extends BaseDockerApiLiveTest {
    protected void tearDown() {
       if (guest != null) {
          adapter.destroyNode(guest.getNode().id() + "");
+      }
+      if (api.getImageApi().inspectImage(CHUANWEN_COWSAY) != null) {
+         api.getImageApi().deleteImage(CHUANWEN_COWSAY);
       }
       super.tearDown();
    }
@@ -103,6 +103,32 @@ public class DockerComputeServiceAdapterLiveTest extends BaseDockerApiLiveTest {
       for (Hardware profile : profiles) {
          assertNotNull(profile);
       }
+   }
+
+   public void testGetImageNotHiddenByCache() {
+
+      //Ensure image to be tested is unknown to jclouds and docker and that cache is warm
+      assertNull(findImageFromListImages(CHUANWEN_COWSAY));
+      assertNull(api.getImageApi().inspectImage(CHUANWEN_COWSAY));
+
+      // Get new image
+      adapter.getImage(CHUANWEN_COWSAY);
+
+      assertNotNull(findImageFromListImages(CHUANWEN_COWSAY), "New image is not available from listImages presumably due to caching");
+   }
+
+   private Image findImageFromListImages(final String image) {
+      return Iterables.find(adapter.listImages(), new Predicate<Image>() {
+        @Override
+        public boolean apply(Image input) {
+           for (String tag : input.repoTags()) {
+              if (tag.equals(image) || tag.equals(CHUANWEN_COWSAY + ":latest")) {
+                 return true;
+              }
+           }
+           return false;
+        }
+     }, null);
    }
 
    @Override

--- a/docker/src/test/java/org/jclouds/docker/compute/DockerComputeServiceLiveTest.java
+++ b/docker/src/test/java/org/jclouds/docker/compute/DockerComputeServiceLiveTest.java
@@ -100,13 +100,7 @@ public class DockerComputeServiceLiveTest extends BaseComputeServiceContextLiveT
       client = view.getComputeService();
 
       String imageName = SSHABLE_IMAGE + ":" + SSHABLE_IMAGE_TAG;
-      org.jclouds.docker.domain.Image image = imageApi().inspectImage(imageName);
-      if (image == null) {
-         CreateImageOptions options = CreateImageOptions.Builder.fromImage(SSHABLE_IMAGE).tag(SSHABLE_IMAGE_TAG);
-         imageApi().createImage(options);
-      }
-      image = imageApi().inspectImage(imageName);
-      defaultImage = client.getImage(image.id());
+      defaultImage = client.getImage(imageName);
       assertNotNull(defaultImage);
    }
 


### PR DESCRIPTION
It would be useful if the docker provider automatically pulled docker images when they are not available locally.  I've changed the behaviour of getImage so that it will now accept an image id of the form sha256:6a0c0700e98ddc24192bec532b107b61cb0d76b27a3a7daeff0cb0a28692d311, tutum/ubuntu, or tutum/ubuntu:3.

