### PR TITLE
Connect container to list of networks in options

### DIFF
--- a/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/docker/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -164,7 +164,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    @Override
    public int hashCode() {
       return Objects.hashCode(super.hashCode(), volumes, hostname, dns, memory, entrypoint, commands, cpuShares, env,
-            portBindings, extraHosts, volumesFrom, privileged, openStdin, configBuilder);
+            portBindings, networkMode, extraHosts, volumesFrom, privileged, openStdin, configBuilder);
    }
 
    @Override
@@ -264,7 +264,11 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    }
 
    /**
-    * Sets the networking mode for the container. Supported values are: bridge, host, and container:[name|id]
+    * Sets the networking mode for the container.
+    * <p>
+    * Supported values are: {@code bridge}, {@code none}, {@code host},
+    * {@code networkname}, {@code networkid} or {@code container:[name|id]}
+    *
     * @param networkMode
     * @return this instance
     */

--- a/docker/src/main/java/org/jclouds/docker/domain/Network.java
+++ b/docker/src/main/java/org/jclouds/docker/domain/Network.java
@@ -17,13 +17,15 @@
 package org.jclouds.docker.domain;
 
 import static org.jclouds.docker.internal.NullSafeCopies.copyOf;
+import static org.jclouds.docker.internal.NullSafeCopies.copyWithNullOf;
+
 import java.util.List;
 import java.util.Map;
 
+import com.google.auto.value.AutoValue;
+
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
-
-import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class Network {
@@ -31,34 +33,75 @@ public abstract class Network {
    @AutoValue
    public abstract static class IPAM {
 
-      IPAM() {} // For AutoValue only!
+      IPAM() { }
 
-      @Nullable
-      public abstract String driver();
+      @Nullable public abstract String driver();
 
       public abstract List<Config> config();
 
       @SerializedNames({"Driver", "Config"})
-      public static IPAM create(String driver, List<Config> config) {
-         return new AutoValue_Network_IPAM(driver, copyOf(config));
+      public static IPAM create(@Nullable String driver, List<Config> config) {
+         return builder()
+               .driver(driver)
+               .config(config)
+               .build();
+      }
+
+      public static Builder builder() {
+         return new AutoValue_Network_IPAM.Builder();
+      }
+
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+         public abstract Builder driver(@Nullable String driver);
+
+         public abstract Builder config(List<Config> config);
+
+         abstract List<Config> config();
+
+         abstract IPAM autoBuild();
+
+         public IPAM build() {
+            return config(copyOf(config()))
+                  .autoBuild();
+         }
       }
 
       @AutoValue
       public abstract static class Config {
 
-         Config() {} // For AutoValue only!
+         Config() { }
 
          public abstract String subnet();
 
-         @Nullable
-         public abstract String ipRange();
+         @Nullable public abstract String ipRange();
 
-         @Nullable
-         public abstract String gateway();
+         @Nullable public abstract String gateway();
 
          @SerializedNames({"Subnet", "IPRange", "Gateway"})
-         public static Config create(String subnet, String ipRange, String gateway) {
-            return new AutoValue_Network_IPAM_Config(subnet, ipRange, gateway);
+         public static Config create(String subnet, @Nullable String ipRange, @Nullable String gateway) {
+            return builder()
+                  .subnet(subnet)
+                  .ipRange(ipRange)
+                  .gateway(gateway)
+                  .build();
+         }
+
+         public static Builder builder() {
+            return new AutoValue_Network_IPAM_Config.Builder();
+         }
+
+         @AutoValue.Builder
+         public abstract static class Builder {
+
+            public abstract Builder subnet(String subnet);
+
+            public abstract Builder ipRange(@Nullable String ipRange);
+
+            public abstract Builder gateway(@Nullable String gateway);
+
+            abstract Config build();
          }
       }
    }
@@ -66,7 +109,7 @@ public abstract class Network {
    @AutoValue
    public abstract static class Details {
 
-      Details() {} // For AutoValue only!
+      Details() { }
 
       public abstract String endpoint();
 
@@ -78,7 +121,30 @@ public abstract class Network {
 
       @SerializedNames({ "EndpointID", "MacAddress", "IPv4Address", "IPv6Address" })
       public static Details create(String endpoint, String macAddress, String ipv4address, String ipv6address) {
-         return new AutoValue_Network_Details(endpoint, macAddress, ipv4address, ipv6address);
+         return builder()
+               .endpoint(endpoint)
+               .macAddress(macAddress)
+               .ipv4address(ipv4address)
+               .ipv6address(ipv6address)
+               .build();
+      }
+
+      public static Builder builder() {
+         return new AutoValue_Network_Details.Builder();
+      }
+
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+         public abstract Builder endpoint(String endpoint);
+
+         public abstract Builder macAddress(String macAddress);
+
+         public abstract Builder ipv4address(String ipv4address);
+
+         public abstract Builder ipv6address(String ipv6address);
+
+         abstract Details build();
       }
    }
 
@@ -92,16 +158,58 @@ public abstract class Network {
 
    @Nullable public abstract IPAM ipam();
 
-   public abstract Map<String, Details> containers();
+   @Nullable public abstract Map<String, Details> containers();
 
-   public abstract Map<String, String> options();
+   @Nullable public abstract Map<String, String> options();
 
-   Network() {}
+   Network() { }
 
    @SerializedNames({ "Name", "Id", "Scope", "Driver", "IPAM", "Containers", "Options" })
-   public static Network create(String name, String id, String scope, String driver, IPAM ipam,
-                                Map<String, Details> containers, Map<String, String> options) {
-      return new AutoValue_Network(name, id, scope, driver, ipam, copyOf(containers), copyOf(options));
+   public static Network create(@Nullable String name, @Nullable String id, @Nullable String scope,
+         @Nullable String driver, @Nullable IPAM ipam, @Nullable Map<String, Details> containers,
+         @Nullable Map<String, String> options) {
+      return builder()
+            .name(name)
+            .id(id)
+            .scope(scope)
+            .driver(driver)
+            .ipam(ipam)
+            .containers(containers)
+            .options(options)
+            .build();
    }
 
+   public static Builder builder() {
+      return new AutoValue_Network.Builder();
+   }
+
+   @AutoValue.Builder
+   public abstract static class Builder {
+
+      public abstract Builder name(@Nullable String name);
+
+      public abstract Builder id(@Nullable String id);
+
+      public abstract Builder scope(@Nullable String scope);
+
+      public abstract Builder driver(@Nullable String driver);
+
+      public abstract Builder ipam(@Nullable IPAM ipam);
+
+      public abstract Builder containers(@Nullable Map<String, Details> containers);
+
+      public abstract Builder options(@Nullable Map<String, String> options);
+
+      abstract Map<String, Details> containers();
+
+      abstract Map<String, String> options();
+
+      abstract Network autoBuild();
+
+      public Network build() {
+         return containers(copyWithNullOf(containers()))
+               .options(copyOf(options()))
+               .autoBuild();
+      }
+   }
 }


### PR DESCRIPTION
Allows connecting a container to more than one virtual network. Note that networks must already exist.