### PR TITLE
[JCLOUDS-1141] azurecompute - fix XML generated by updateRole REST call

### DIFF
--- a/azurecompute/src/main/java/org/jclouds/azurecompute/binders/RoleToXML.java
+++ b/azurecompute/src/main/java/org/jclouds/azurecompute/binders/RoleToXML.java
@@ -75,6 +75,9 @@ public class RoleToXML implements Binder {
                  .e("OS").t(role.osVirtualHardDisk().os().toString()).up()
                  .up() // OSVirtualHardDisk
                  .e("RoleSize").t(role.roleSize().getText());
+         if (role.provisionGuestAgent() != null) {
+            builder.e("ProvisionGuestAgent").t(role.provisionGuestAgent().toString()).up();
+         }
          return (R) request.toBuilder().payload(builder.asString()).build();
       } catch (Exception e) {
          throw propagate(e);

--- a/azurecompute/src/main/java/org/jclouds/azurecompute/binders/RoleToXML.java
+++ b/azurecompute/src/main/java/org/jclouds/azurecompute/binders/RoleToXML.java
@@ -24,6 +24,9 @@ import org.jclouds.rest.Binder;
 
 import com.jamesmurty.utils.XMLBuilder;
 
+/**
+ * Generates XML request body for the <a href="https://msdn.microsoft.com/en-us/library/azure/jj157187.aspx">UpdateRole REST request</a>.
+ */
 public class RoleToXML implements Binder {
 
    @Override
@@ -32,14 +35,13 @@ public class RoleToXML implements Binder {
       Role role = Role.class.cast(input);
 
       try {
-         XMLBuilder builder = XMLBuilder.create("PersistentVMRole", "http://schemas.microsoft.com/windowsazure")
-                 .e("RoleName").t(role.roleName()).up()
-                 .e("RoleType").t(role.roleType()).up()
-                 .e("ConfigurationSets");
-
+         XMLBuilder builder = XMLBuilder.create("PersistentVMRole", "http://schemas.microsoft.com/windowsazure");
+         builder.e("RoleName").t(role.roleName()).up()
+                 .e("RoleType").t(role.roleType()).up();
+         XMLBuilder configSetsBuilder = builder.e("ConfigurationSets");
          if (!role.configurationSets().isEmpty()) {
             for (Role.ConfigurationSet configurationSet : role.configurationSets()) {
-               XMLBuilder configBuilder = builder.e("ConfigurationSet"); // Network
+               XMLBuilder configBuilder = configSetsBuilder.e("ConfigurationSet"); // Network
                configBuilder.e("ConfigurationSetType").t(configurationSet.configurationSetType()).up();
 
                XMLBuilder inputEndpoints = configBuilder.e("InputEndpoints");
@@ -63,6 +65,7 @@ public class RoleToXML implements Binder {
                }
             }
          }
+         
          builder.e("DataVirtualHardDisks").up()
                  .e("OSVirtualHardDisk")
                  .e("HostCaching").t(role.osVirtualHardDisk().hostCaching()).up()
@@ -70,7 +73,7 @@ public class RoleToXML implements Binder {
                  .e("MediaLink").t(role.osVirtualHardDisk().mediaLink().toString()).up()
                  .e("SourceImageName").t(role.osVirtualHardDisk().sourceImageName()).up()
                  .e("OS").t(role.osVirtualHardDisk().os().toString()).up()
-                 .up() // DataVirtualHardDisks
+                 .up() // OSVirtualHardDisk
                  .e("RoleSize").t(role.roleSize().getText());
          return (R) request.toBuilder().payload(builder.asString()).build();
       } catch (Exception e) {

--- a/azurecompute/src/main/java/org/jclouds/azurecompute/compute/AzureComputeServiceAdapter.java
+++ b/azurecompute/src/main/java/org/jclouds/azurecompute/compute/AzureComputeServiceAdapter.java
@@ -134,6 +134,7 @@ public class AzureComputeServiceAdapter implements ComputeServiceAdapter<Deploym
               .externalEndpoints(externalEndpoints)
               .virtualNetworkName(templateOptions.getVirtualNetworkName())
               .subnetNames(templateOptions.getSubnetNames())
+              .provisionGuestAgent(templateOptions.getProvisionGuestAgent())
               .build();
 
       message = String.format("Creating a deployment with params '%s' ...", params);

--- a/azurecompute/src/main/java/org/jclouds/azurecompute/compute/options/AzureComputeTemplateOptions.java
+++ b/azurecompute/src/main/java/org/jclouds/azurecompute/compute/options/AzureComputeTemplateOptions.java
@@ -53,6 +53,7 @@ public class AzureComputeTemplateOptions extends TemplateOptions implements Clon
    protected String storageAccountType;
    protected String networkSecurityGroupName;
    protected String reservedIPName;
+   protected Boolean provisionGuestAgent;
 
    @Override
    public AzureComputeTemplateOptions clone() {
@@ -73,6 +74,7 @@ public class AzureComputeTemplateOptions extends TemplateOptions implements Clon
          eTo.storageAccountName(storageAccountName);
          eTo.storageAccountType(storageAccountType);
          eTo.reservedIPName(reservedIPName);
+         eTo.provisionGuestAgent(provisionGuestAgent);
       }
    }
 
@@ -91,6 +93,7 @@ public class AzureComputeTemplateOptions extends TemplateOptions implements Clon
       if (storageAccountType != null ? !storageAccountType.equals(that.storageAccountType) : that.storageAccountType != null) return false;
       if (subnetNames != null ? !subnetNames.equals(that.subnetNames) : that.subnetNames != null) return false;
       if (virtualNetworkName != null ? !virtualNetworkName.equals(that.virtualNetworkName) : that.virtualNetworkName != null) return false;
+      if (provisionGuestAgent != null ? !provisionGuestAgent.equals(that.provisionGuestAgent) : that.provisionGuestAgent != null) return false;
 
       return true;
    }
@@ -104,6 +107,7 @@ public class AzureComputeTemplateOptions extends TemplateOptions implements Clon
       result = 31 * result + (storageAccountType != null ? storageAccountType.hashCode() : 0);
       result = 31 * result + (networkSecurityGroupName != null ? networkSecurityGroupName.hashCode() : 0);
       result = 31 * result + (reservedIPName != null ? reservedIPName.hashCode() : 0);
+      result = 31 * result + (provisionGuestAgent != null ? provisionGuestAgent.hashCode() : 0);
       return result;
    }
 
@@ -116,6 +120,7 @@ public class AzureComputeTemplateOptions extends TemplateOptions implements Clon
               .add("storageAccountType", storageAccountType)
               .add("networkSecurityGroupName", networkSecurityGroupName)
               .add("reservedIPName", reservedIPName)
+              .add("provisionGuestAgent", provisionGuestAgent)
               .toString();
    }
 
@@ -154,6 +159,11 @@ public class AzureComputeTemplateOptions extends TemplateOptions implements Clon
       return this;
    }
 
+   public AzureComputeTemplateOptions provisionGuestAgent(@Nullable Boolean provisionGuestAgent) {
+      this.provisionGuestAgent = provisionGuestAgent;
+      return this;
+   }
+
    public String getVirtualNetworkName() {
       return virtualNetworkName;
    }
@@ -176,6 +186,10 @@ public class AzureComputeTemplateOptions extends TemplateOptions implements Clon
 
    public String getReservedIPName() {
       return reservedIPName;
+   }
+
+   public Boolean getProvisionGuestAgent() {
+      return provisionGuestAgent;
    }
 
    public static class Builder {

--- a/azurecompute/src/main/java/org/jclouds/azurecompute/domain/DeploymentParams.java
+++ b/azurecompute/src/main/java/org/jclouds/azurecompute/domain/DeploymentParams.java
@@ -126,6 +126,16 @@ public abstract class DeploymentParams {
 
    public abstract List<String> subnetNames();
 
+   /**
+    * Optional. Indicates whether the VM Agent is installed on the Virtual
+    * Machine. To run a resource extension in a Virtual Machine, this agent must
+    * be installed.
+    *
+    * @return provisionGuestAgent true/false flag (or null)
+    */
+   @Nullable
+   public abstract Boolean provisionGuestAgent();
+
    public static Builder builder() {
       return new AutoValue_DeploymentParams.Builder()
               .externalEndpoints(ImmutableSet.<ExternalEndpoint> of())
@@ -147,6 +157,7 @@ public abstract class DeploymentParams {
       public abstract Builder virtualNetworkName(String virtualNetworkName);
       public abstract Builder reservedIPName(String reservedIPName);
       public abstract Builder subnetNames(List<String> subnetNames);
+      public abstract Builder provisionGuestAgent(Boolean provisionGuestAgent);
 
       abstract Set<ExternalEndpoint> externalEndpoints();
       abstract List<String> subnetNames();
@@ -164,11 +175,12 @@ public abstract class DeploymentParams {
                                          String password, String sourceImageName, URI mediaLink,
                                          OSImage.Type os, Set<ExternalEndpoint> externalEndpoints,
                                          String virtualNetworkName, String reservedIPName,
-                                         List<String> subnetNames) {
+                                         List<String> subnetNames, Boolean provisionGuestAgent) {
       return builder().name(name).size(size).username(username).password(password)
               .sourceImageName(sourceImageName).mediaLink(mediaLink).os(os)
               .externalEndpoints(externalEndpoints).virtualNetworkName(virtualNetworkName)
               .reservedIPName(reservedIPName).subnetNames(subnetNames)
+              .provisionGuestAgent(provisionGuestAgent)
               .build();
    }
 }

--- a/azurecompute/src/test/java/org/jclouds/azurecompute/features/VirtualMachineApiMockTest.java
+++ b/azurecompute/src/test/java/org/jclouds/azurecompute/features/VirtualMachineApiMockTest.java
@@ -18,12 +18,17 @@ package org.jclouds.azurecompute.features;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
 import org.jclouds.azurecompute.domain.Role;
 import org.jclouds.azurecompute.internal.BaseAzureComputeApiMockTest;
 import org.jclouds.azurecompute.xml.RoleHandlerTest;
 import org.testng.annotations.Test;
 
+import com.google.common.io.ByteStreams;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 /*
  * Note: Mock test for CaptureVMImage method is in VMImageApiMockTest class
@@ -109,7 +114,14 @@ public class VirtualMachineApiMockTest extends BaseAzureComputeApiMockTest {
          Role role = RoleHandlerTest.expected();
          assertThat(api.updateRole("testvnetsg02", role)).isEqualTo("request-1");
 
-         assertSent(server, "PUT", "/services/hostedservices/my-service/deployments/mydeployment/roles/testvnetsg02");
+         RecordedRequest request = assertSent(server, "PUT", "/services/hostedservices/my-service/deployments/mydeployment/roles/testvnetsg02");
+         
+         final InputStream is = getClass().getResourceAsStream("/role-update-body.xml");
+         try {
+            assertThat(request.getUtf8Body()).isXmlEqualTo(new String(ByteStreams.toByteArray(is), Charset.forName("UTF-8")));
+         } finally {
+            is.close();
+         }
       } finally {
          server.shutdown();
       }

--- a/azurecompute/src/test/resources/role-update-body.xml
+++ b/azurecompute/src/test/resources/role-update-body.xml
@@ -33,4 +33,5 @@
     <OS>WINDOWS</OS>
   </OSVirtualHardDisk>
   <RoleSize>Small</RoleSize>
+  <ProvisionGuestAgent>true</ProvisionGuestAgent>
 </PersistentVMRole>

--- a/azurecompute/src/test/resources/role-update-body.xml
+++ b/azurecompute/src/test/resources/role-update-body.xml
@@ -1,0 +1,36 @@
+<PersistentVMRole xmlns="http://schemas.microsoft.com/windowsazure">
+  <RoleName>testvnetsg02</RoleName>
+  <RoleType>PersistentVMRole</RoleType>
+  <ConfigurationSets>
+    <ConfigurationSet>
+      <ConfigurationSetType>NetworkConfiguration</ConfigurationSetType>
+      <InputEndpoints>
+        <InputEndpoint>
+          <LocalPort>5986</LocalPort>
+          <Name>PowerShell</Name>
+          <Port>5986</Port>
+          <Protocol>tcp</Protocol>
+        </InputEndpoint>
+        <InputEndpoint>
+          <LocalPort>3389</LocalPort>
+          <Name>Remote Desktop</Name>
+          <Port>59440</Port>
+          <Protocol>tcp</Protocol>
+        </InputEndpoint>
+      </InputEndpoints>
+      <SubnetNames>
+        <SubnetName>Subnet-1</SubnetName>
+      </SubnetNames>
+      <NetworkSecurityGroup>vnetnsgsg01</NetworkSecurityGroup>
+    </ConfigurationSet>
+  </ConfigurationSets>
+  <DataVirtualHardDisks />
+  <OSVirtualHardDisk>
+    <HostCaching>ReadWrite</HostCaching>
+    <DiskName>testvnetsg02-testvnetsg02-0-201502180825130518</DiskName>
+    <MediaLink>https://portalvhdsxz8nc6chc32j1.blob.core.windows.net/vhds/testvnetsg02-testvnetsg02-2015-02-18.vhd</MediaLink>
+    <SourceImageName>a699494373c04fc0bc8f2bb1389d6106__Windows-Server-2012-R2-201412.01-en.us-127GB.vhd</SourceImageName>
+    <OS>WINDOWS</OS>
+  </OSVirtualHardDisk>
+  <RoleSize>Small</RoleSize>
+</PersistentVMRole>


### PR DESCRIPTION
JIRAs:
* https://issues.apache.org/jira/browse/JCLOUDS-1141
  * Fixes XML generated by `RoleToXML` binder class.
* https://issues.apache.org/jira/browse/JCLOUDS-1142
  * Adds suport for `ProvisionGuestAgent` flag configuration of deployment Role