### PR TITLE
JCLOUDS-1170 The azurecompute provider should remove disk blobs

### DIFF
--- a/azurecompute/src/main/java/org/jclouds/azurecompute/features/DiskApi.java
+++ b/azurecompute/src/main/java/org/jclouds/azurecompute/features/DiskApi.java
@@ -33,6 +33,7 @@ import org.jclouds.azurecompute.functions.ParseRequestIdHeader;
 import org.jclouds.azurecompute.xml.ListDisksHandler;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.Headers;
+import org.jclouds.rest.annotations.QueryParams;
 import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.XMLResponseParser;
 
@@ -63,6 +64,7 @@ public interface DiskApi {
    @Named("DeleteDisk")
    @DELETE
    @Path("/{diskName}")
+   @QueryParams(keys = "comp", values = "media")
    @Fallback(NullOnNotFoundOr404.class)
    @ResponseParser(ParseRequestIdHeader.class)
    String delete(@PathParam("diskName") String diskName);

--- a/azurecompute/src/test/java/org/jclouds/azurecompute/features/DiskApiMockTest.java
+++ b/azurecompute/src/test/java/org/jclouds/azurecompute/features/DiskApiMockTest.java
@@ -51,7 +51,7 @@ public class DiskApiMockTest extends BaseAzureComputeApiMockTest {
 
          assertEquals(api.delete("my-disk"), "request-1");
 
-         assertSent(server, "DELETE", "/services/disks/my-disk");
+         assertSent(server, "DELETE", "/services/disks/my-disk?comp=media");
       } finally {
          server.shutdown();
       }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/JCLOUDS-1170

This fixes removing VM disks on Azure. There was missing query parameter in the API call, which caused increasing storage consumption because the data blobs were not deleted for the removed disks.