### PR TITLE
[JCLOUDS-1219] initial commit for Packet.net API

### DIFF
--- a/packet/README.md
+++ b/packet/README.md
@@ -1,0 +1,1 @@
+# Apache jclouds Packet (packet.net) provider

--- a/packet/pom.xml
+++ b/packet/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jclouds.labs</groupId>
+        <artifactId>jclouds-labs</artifactId>
+        <version>2.1.0-SNAPSHOT</version>
+    </parent>
+
+    <!-- TODO: when out of labs, switch to org.jclouds.provider -->
+    <artifactId>packet</artifactId>
+    <name>jclouds Packet compute API</name>
+    <description>jclouds components to access an implementation of Packet's Compute Service</description>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <test.packet.endpoint>https://api.packet.net/</test.packet.endpoint>
+        <test.packet.identity>projectId</test.packet.identity>
+        <test.packet.credential>api key</test.packet.credential>
+        <jclouds.osgi.export>org.jclouds.packet*;version="${project.version}"</jclouds.osgi.export>
+        <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.jclouds</groupId>
+            <artifactId>jclouds-compute</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jclouds</groupId>
+            <artifactId>jclouds-compute</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jclouds.driver</groupId>
+            <artifactId>jclouds-slf4j</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jclouds.driver</groupId>
+            <artifactId>jclouds-slf4j</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jclouds.driver</groupId>
+            <artifactId>jclouds-sshj</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Already provided by jclouds-sshj -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>live</id>
+
+            <build>
+                <defaultGoal>clean verify</defaultGoal>
+
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>integration</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <test.packet.endpoint>${test.packet.endpoint}</test.packet.endpoint>
+                                        <test.packet.identity>${test.packet.identity}</test.packet.identity>
+                                        <test.packet.credential>${test.packet.credential}</test.packet.credential>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/packet/src/main/java/org/jclouds/packet/domain/ActionType.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/ActionType.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+/**
+ * Performs an action for the given device. Possible actions include:
+
+ power_on
+ power_off
+ reboot
+ rescue: reboot the device into rescue OS.
+ */
+public enum ActionType {
+    
+    POWER_ON ("power_on"),
+    POWER_OFF ("power_off"),
+    REBOOT ("reboot"),
+    RESCUE ("rescue");
+
+    private final String type;
+
+    ActionType(String type) {
+        this.type = type;
+    }
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/BillingCycle.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/BillingCycle.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.List;
+
+import com.google.common.base.Predicate;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.tryFind;
+import static java.util.Arrays.asList;
+
+public enum BillingCycle {
+   HOURLY("hourly"),
+   MONTHLY("monthly"),
+   UNRECOGNIZED("");
+
+   private static final List<BillingCycle> values = asList(BillingCycle.values());
+
+   private final String value;
+
+   private BillingCycle(String value) {
+      this.value = checkNotNull(value, "value cannot be null");
+   }
+
+   public String value() {
+      return this.value;
+   }
+
+   public static BillingCycle fromValue(String value) {
+      return tryFind(values, hasValue(value)).or(UNRECOGNIZED);
+   }
+
+   private static Predicate<BillingCycle> hasValue(final String value) {
+      return new Predicate<BillingCycle>() {
+         @Override
+         public boolean apply(BillingCycle input) {
+            return input.value.equalsIgnoreCase(value);
+         }
+      };
+   }
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Device.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Device.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.Date;
+import java.util.List;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@AutoValue
+public abstract class Device {
+
+    public enum State {
+        PROVISIONING, QUEUED, ACTIVE;
+
+        public static State fromValue(String value) {
+            Optional<State> state = Enums.getIfPresent(State.class, value.toUpperCase());
+            checkArgument(state.isPresent(), "Expected one of %s but was %s", Joiner.on(',').join(State.values()), value);
+            return state.get();
+        }
+    }
+
+    public abstract String id();
+    public abstract String shortId();
+    public abstract String hostname();
+    @Nullable
+    public abstract String description();
+    public abstract State state();
+    public abstract List<String> tags();
+    public abstract String billingCycle();
+    public abstract String user();
+    public abstract String iqn();
+    public abstract Boolean locked();
+    public abstract String bondingMode();
+    public abstract Date createdAt();
+    public abstract Date updatedAt();
+    public abstract OperatingSystem operatingSystem();
+    public abstract Facility facility();
+    public abstract Href project();
+    public abstract Href projectLite();
+    public abstract List<Object> volumes();
+    public abstract List<IpAddress> ipAddresses();
+    public abstract Plan plan();
+    public abstract String rootPassword();
+    public abstract String userdata();
+    public abstract String href();
+
+    @SerializedNames({"id", "short_id", "hostname", "description", "state", "tags", "billing_cycle", "user", "iqn", "locked", "bonding_mode", "created_at", "updated_at", "operating_system", "facility", "project", "project_lite", "volumes", "ip_addresses", "plan", "root_password", "userdata", "href"})
+    public static Device create(String id,
+                                String shortId,
+                                String hostname,
+                                String description,
+                                State state,
+                                List<String> tags,
+                                String billingCycle,
+                                String user,
+                                String iqn,
+                                Boolean locked,
+                                String bondingMode,
+                                Date createdAt,
+                                Date updatedAt,
+                                OperatingSystem operatingSystem,
+                                Facility facility,
+                                Href project,
+                                Href projectLite,
+                                List<Object> volumes,
+                                List<IpAddress> ipAddresses,
+                                Plan plan,
+                                String rootPassword,
+                                String userdata,
+                                String href
+    ) {
+        return new AutoValue_Device(id, shortId, hostname, description, state,
+                tags == null ? ImmutableList.<String> of() : ImmutableList.copyOf(tags),
+                billingCycle, user, iqn, locked, bondingMode, createdAt, updatedAt, operatingSystem, facility, project, projectLite,
+                volumes == null ? ImmutableList.of() : ImmutableList.copyOf(volumes),
+                ipAddresses == null ? ImmutableList.<IpAddress>of() : ImmutableList.copyOf(ipAddresses),
+                plan, rootPassword, userdata, href
+        );
+    }
+
+    Device() {
+    }
+
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Distribution.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Distribution.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.List;
+
+import org.jclouds.compute.domain.OsFamily;
+
+import com.google.common.base.Predicate;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.tryFind;
+import static java.util.Arrays.asList;
+
+public enum Distribution {
+   
+   CENTOS(OsFamily.CENTOS, "centos"),
+   COREOS(OsFamily.COREOS, "coreos"),
+   DEBIAN(OsFamily.DEBIAN, "debian"),
+   UBUNTU(OsFamily.UBUNTU, "ubuntu"),
+   WINDOWS(OsFamily.WINDOWS, "windows"),
+   UNRECOGNIZED(OsFamily.UNRECOGNIZED, "");
+
+   private static final List<Distribution> values = asList(Distribution.values());
+
+   private final OsFamily osFamily;
+   private final String value;
+
+   private Distribution(OsFamily osFamily, String value) {
+      this.osFamily = checkNotNull(osFamily, "osFamily cannot be null");
+      this.value = checkNotNull(value, "value cannot be null");
+   }
+
+   public OsFamily osFamily() {
+      return this.osFamily;
+   }
+
+   public String value() {
+      return this.value;
+   }
+
+   public static Distribution fromValue(String value) {
+      return tryFind(values, hasValue(value)).or(UNRECOGNIZED);
+   }
+
+   private static Predicate<Distribution> hasValue(final String value) {
+      return new Predicate<Distribution>() {
+         @Override
+         public boolean apply(Distribution input) {
+            return input.value.equalsIgnoreCase(value);
+         }
+      };
+   }
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Facility.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Facility.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.List;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+public abstract class Facility {
+
+    public abstract String id();
+    public abstract String name();
+    public abstract String code();
+    public abstract List<String> features();
+    @Nullable
+    public abstract String address();
+
+    @SerializedNames({"id", "name", "code", "features", "address"})
+    public static Facility create(final String id, String name, String code, List<String> features, String address) {
+        return new AutoValue_Facility(id, name, code,
+                features == null ? ImmutableList.<String> of() : ImmutableList.copyOf(features),
+                address);
+    }
+
+    Facility() {}
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Href.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Href.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class Href {
+
+    public abstract String href();
+
+    @SerializedNames({ "href" })
+    public static Href create(String href) {
+        return new AutoValue_Href(href);
+    }
+
+    Href() {}
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/IpAddress.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/IpAddress.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class IpAddress {
+
+    public abstract String id();
+    public abstract Integer addressFamily();
+    public abstract String netmask();
+    public abstract Boolean publicAddress();
+    public abstract Integer cidr();
+    public abstract Boolean management();
+    public abstract Boolean manageable();
+    public abstract Href assignedTo();
+    public abstract String network();
+    public abstract String address();
+    public abstract String gateway();
+    public abstract String href();
+
+    @SerializedNames({"id", "address_family", "netmask", "public", "cidr", "management", "manageable", "assigned_to", "network", "address", "gateway", "href"})
+    public static IpAddress create(
+            String id,
+            Integer addressFamily,
+            String netmask,
+            Boolean publicAddress,
+            Integer cidr,
+            Boolean management,
+            Boolean manageable,
+            Href assignedTo,
+            String network,
+            String address,
+            String gateway,
+            String href
+    ) {
+        return new AutoValue_IpAddress(id, addressFamily, netmask, publicAddress, cidr, management, manageable, assignedTo, network, address, gateway, href
+        );
+    }
+
+    IpAddress() {}
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/OperatingSystem.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/OperatingSystem.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.Set;
+
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+@AutoValue
+public abstract class OperatingSystem {
+
+    public abstract String id();
+    public abstract String slug();
+    public abstract String name();
+    public abstract String distribution();
+    public abstract String version();
+    public abstract Set<String> provisionableOn();
+
+    @SerializedNames({"id", "slug", "name", "distro", "version", "provisionable_on"})
+    public static OperatingSystem create(String id, String slug, String name, String distribution, String version, Set<String> provisionableOn) {
+        return new AutoValue_OperatingSystem(id, slug, name, distribution, version,
+                provisionableOn == null ? ImmutableSet.<String> of() : ImmutableSet.copyOf(provisionableOn)
+        );
+    }
+
+    OperatingSystem() {}
+
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Plan.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Plan.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.List;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+public abstract class Plan {
+
+    public abstract String id();
+    public abstract String slug();
+    public abstract String name();
+    public abstract String description();
+    public abstract String line();
+    @Nullable
+    public abstract Specs specs();
+    public abstract List<Href> availableIn();
+    public abstract Pricing pricing();
+
+    @SerializedNames({"id", "slug", "name", "description", "line", "specs", "available_in", "pricing"})
+    public static Plan create(final String id, String slug, String name, String description, String line, Specs specs, List<Href> availableIn, Pricing pricing) {
+        return new AutoValue_Plan(id, slug, name, description, line,
+                specs,
+                availableIn == null ? ImmutableList.<Href> of() : ImmutableList.copyOf(availableIn),
+                pricing
+        );
+    }
+
+    Plan() {}
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Pricing.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Pricing.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class Pricing {
+
+    public abstract double hour();
+
+    @SerializedNames({ "hour" })
+    public static Pricing create(double hour) {
+        return new AutoValue_Pricing(hour);
+    }
+
+    Pricing() {}
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Project.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Project.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+@AutoValue
+public abstract class Project {
+
+    public abstract String id();
+    public abstract String name();
+    public abstract Date createdAt();
+    public abstract Date updatedAt();
+    public abstract Map<String, Object> maxDevices();
+    public abstract List<Href> members();
+    public abstract List<Href> memberships();
+    public abstract List<Href> invitations();
+    public abstract Href paymentMethod();
+    public abstract List<Href> devices();
+    public abstract List<Href> sshKeys();
+    public abstract List<Href> volumes();
+    public abstract String href();
+
+    @SerializedNames({"id", "name", "created_at", "updated_at", "max_devices", "members", "memberships", "invitations", "payment_method", "devices", "ssh_keys", "volumes", "href"})
+    public static Project create(String id, String name, Date createdAt, Date updatedAt, Map<String, Object> maxDevices,
+                                 List<Href> members, List<Href> memberships, List<Href> invitations, Href paymentMethod,
+                                 List<Href> devices,
+                                 List<Href> sshKeys,
+                                 List<Href> volumes,
+                                 String href) {
+        return new AutoValue_Project(id, name, createdAt, updatedAt,
+                maxDevices == null ? ImmutableMap.<String, Object> of() : ImmutableMap.copyOf(maxDevices),
+                members == null ? ImmutableList.<Href> of() : ImmutableList.copyOf(members),
+                memberships == null ? ImmutableList.<Href> of() : ImmutableList.copyOf(memberships),
+                invitations == null ? ImmutableList.<Href> of() : ImmutableList.copyOf(invitations),
+                paymentMethod,
+                devices == null ? ImmutableList.<Href> of() : ImmutableList.copyOf(devices),
+                sshKeys == null ? ImmutableList.<Href> of() : ImmutableList.copyOf(sshKeys),
+                volumes == null ? ImmutableList.<Href> of() : ImmutableList.copyOf(volumes),
+                href);
+    }
+
+    Project() {}
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Specs.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Specs.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+@AutoValue
+public abstract class Specs {
+
+    @AutoValue
+    public abstract static class NIC {
+
+        public abstract Integer count();
+        public abstract String type();
+
+        @SerializedNames({ "count", "type" })
+        public static NIC create(Integer count, String type) {
+            return new AutoValue_Specs_NIC(count, type);
+        }
+    }
+
+    @AutoValue
+    public abstract static class Drive {
+
+        public abstract Integer count();
+        public abstract String size();
+        public abstract String type();
+
+        @SerializedNames({ "count", "size", "type" })
+        public static Drive create(Integer count, String size, String type) {
+            return new AutoValue_Specs_Drive(count, size, type);
+        }
+    }
+
+    @AutoValue
+    public abstract static class CPU {
+
+        public abstract Integer count();
+        public abstract String type();
+
+        @SerializedNames({ "count", "type" })
+        public static CPU create(Integer count, String type) {
+            return new AutoValue_Specs_CPU(count, type);
+        }
+    }
+
+    @AutoValue
+    public abstract static class Memory {
+
+        public abstract String total();
+
+        @SerializedNames({ "total" })
+        public static Memory create(String total) {
+            return new AutoValue_Specs_Memory(total);
+        }
+    }
+
+    public abstract List<CPU> cpus();
+    public abstract Memory memory();
+    public abstract List<Drive> drives();
+    public abstract List<NIC> nics();
+    public abstract Map<String, Object> features();
+
+    @SerializedNames({"cpus", "memory", "drives", "nics", "features"})
+    public static Specs create(List<CPU> cpus, Memory memory, List<Drive> drives, List<NIC> nics, Map<String, Object> features) {
+        return new AutoValue_Specs(
+                cpus == null ? ImmutableList.<CPU> of() : ImmutableList.copyOf(cpus),
+                memory,
+                drives == null ? ImmutableList.<Drive> of() : ImmutableList.copyOf(drives),
+                nics == null ? ImmutableList.<NIC> of() : ImmutableList.copyOf(nics),
+                features == null ? ImmutableMap.<String, Object> of() : ImmutableMap.copyOf(features)
+        );
+    }
+
+    Specs() {}
+
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/SshKey.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/SshKey.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.domain;
+
+import java.util.Date;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class SshKey {
+
+    @AutoValue
+    public abstract static class Owner {
+
+        public abstract String href();
+
+        @SerializedNames({ "href" })
+        public static Owner create(String href) {
+            return new AutoValue_SshKey_Owner(href);
+        }
+    }
+
+    public abstract String id();
+    public abstract String label();
+    public abstract String key();
+    public abstract String fingerprint();
+    public abstract Date createdAt();
+    public abstract Date updatedAt();
+    @Nullable public abstract Owner owner();
+    public abstract String href();
+
+    @SerializedNames({"id", "label", "key", "fingerprint", "created_at", "updated_at", "owner", "href"})
+    public static SshKey create(String id, String label, String key, String fingerprint, Date createdAt, Date updatedAt, Owner owner, String href) {
+        return new AutoValue_SshKey(id, label, key, fingerprint, createdAt, updatedAt, owner, href);
+    }
+
+    SshKey() {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <module>abiquo</module>
     <module>profitbricks-rest</module>
     <module>oneandone</module>
+    <module>packet</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This is the first PR for Packet API, to simplify the review process, and it only adds the pom.xml and the domain objects, based on https://www.packet.net/developers/api/ 
Those are the minimum set needed to support the jclouds abstraction.
