### PR TITLE
JCLOUDS-1224: Update B2 domain

### DIFF
--- a/b2/src/main/java/org/jclouds/b2/B2ApiMetadata.java
+++ b/b2/src/main/java/org/jclouds/b2/B2ApiMetadata.java
@@ -65,7 +65,7 @@ public final class B2ApiMetadata extends BaseHttpApiMetadata {
                  .identityName("Account Id")
                  .credentialName("Application Key")
                  .documentation(URI.create("https://www.backblaze.com/b2/docs/"))
-                 .defaultEndpoint("https://api.backblaze.com/")
+                 .defaultEndpoint("https://api.backblazeb2.com/")
                  .defaultProperties(B2ApiMetadata.defaultProperties())
                  .view(typeToken(BlobStoreContext.class))
                  .defaultModules(ImmutableSet.<Class<? extends Module>>of(

--- a/b2/src/main/java/org/jclouds/b2/B2ProviderMetadata.java
+++ b/b2/src/main/java/org/jclouds/b2/B2ProviderMetadata.java
@@ -49,7 +49,7 @@ public final class B2ProviderMetadata extends BaseProviderMetadata {
          id("b2")
                  .name("Backblaze B2")
                  .apiMetadata(new B2ApiMetadata())
-                 .endpoint("https://api.backblaze.com/")
+                 .endpoint("https://api.backblazeb2.com/")
                  .defaultProperties(B2ProviderMetadata.defaultProperties());
       }
 


### PR DESCRIPTION
The old domain will no longer function after 2 Feb 2017.  Reference:

https://help.backblaze.com/hc/en-us/articles/224959187-B2-Domain-Migration-Plan