### PR TITLE
Feature/packet 5

### DIFF
--- a/packet/src/main/java/org/jclouds/packet/PacketApiMetadata.java
+++ b/packet/src/main/java/org/jclouds/packet/PacketApiMetadata.java
@@ -20,6 +20,8 @@ import java.net.URI;
 import java.util.Properties;
 
 import org.jclouds.apis.ApiMetadata;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.packet.compute.config.PacketComputeServiceContextModule;
 import org.jclouds.packet.config.PacketComputeParserModule;
 import org.jclouds.packet.config.PacketHttpApiModule;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
@@ -29,6 +31,8 @@ import com.google.inject.Module;
 
 import static org.jclouds.compute.config.ComputeServiceProperties.TEMPLATE;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
+import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
+import static org.jclouds.reflect.Reflection2.typeToken;
 
 /**
  * Implementation of {@link ApiMetadata} for Packet API
@@ -52,6 +56,7 @@ public class PacketApiMetadata extends BaseHttpApiMetadata<PacketApi> {
       Properties properties = BaseHttpApiMetadata.defaultProperties();
       properties.put(TEMPLATE, "osFamily=UBUNTU,os64Bit=true,osVersionMatches=16.*");
       properties.put(TIMEOUT_NODE_RUNNING, 300000); // 5 mins
+      properties.put(TIMEOUT_NODE_SUSPENDED, 300000); // 5 mins
       return properties;
    }
 
@@ -66,11 +71,11 @@ public class PacketApiMetadata extends BaseHttpApiMetadata<PacketApi> {
                  .defaultEndpoint("https://api.packet.net")
                  .defaultProperties(PacketApiMetadata.defaultProperties())
                  .version("1")
-                 //.view(typeToken(ComputeServiceContext.class))
+                 .view(typeToken(ComputeServiceContext.class))
                  .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                          .add(PacketHttpApiModule.class)
                          .add(PacketComputeParserModule.class)
-                         //.add(PacketComputeServiceContextModule.class)
+                         .add(PacketComputeServiceContextModule.class)
                          .build());
       }
 

--- a/packet/src/main/java/org/jclouds/packet/compute/PacketComputeServiceAdapter.java
+++ b/packet/src/main/java/org/jclouds/packet/compute/PacketComputeServiceAdapter.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.compute;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jclouds.compute.ComputeServiceAdapter;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.domain.Credentials;
+import org.jclouds.location.Provider;
+import org.jclouds.logging.Logger;
+import org.jclouds.packet.PacketApi;
+import org.jclouds.packet.compute.options.PacketTemplateOptions;
+import org.jclouds.packet.domain.BillingCycle;
+import org.jclouds.packet.domain.Device;
+import org.jclouds.packet.domain.Facility;
+import org.jclouds.packet.domain.OperatingSystem;
+import org.jclouds.packet.domain.Plan;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Iterables;
+
+import static com.google.common.collect.Iterables.contains;
+import static com.google.common.collect.Iterables.filter;
+
+/**
+ * defines the connection between the {@link org.jclouds.packet.PacketApi} implementation and
+ * the jclouds {@link org.jclouds.compute.ComputeService}
+ */
+@Singleton
+public class PacketComputeServiceAdapter implements ComputeServiceAdapter<Device, Plan, OperatingSystem, Facility> {
+
+   @Resource
+   @Named(ComputeServiceConstants.COMPUTE_LOGGER)
+   protected Logger logger = Logger.NULL;
+
+   private final PacketApi api;
+   private final String projectId;
+
+   @Inject
+   PacketComputeServiceAdapter(PacketApi api, @Provider final Supplier<Credentials> creds) {
+      this.api = api;
+      this.projectId = creds.get().identity;
+   }
+
+   @Override
+   public NodeAndInitialCredentials<Device> createNodeWithGroupEncodedIntoName(String group, String name, Template template) {
+
+      PacketTemplateOptions templateOptions = template.getOptions().as(PacketTemplateOptions.class);
+      Map<String, String> features = templateOptions.getFeatures();
+      BillingCycle billingCycle = BillingCycle.fromValue(templateOptions.getBillingCycle());
+      boolean locked = templateOptions.isLocked();
+      String userdata = templateOptions.getUserData();
+      Set<String> tags = templateOptions.getTags();
+
+      String plan = template.getHardware().getId();
+      String facility = template.getLocation().getId();
+      String operatingSystem = template.getImage().getId();
+
+      Device device = api.deviceApi(projectId).create(
+              Device.CreateDevice.builder()
+                      .hostname(name)
+                      .plan(plan)
+                      .billingCycle(billingCycle.value())
+                      .facility(facility)
+                      .features(features)
+                      .operatingSystem(operatingSystem)
+                      .locked(locked)
+                      .userdata(userdata)
+                      .tags(tags)
+                      .build()
+              );
+
+      // Any new servers you deploy to projects you are a collaborator on will have your project and personal SSH keys, if defined.
+      // If no SSH keys are defined in your account, jclouds will generate one usiing CreateSshKeysThenCreateNodes 
+      // so that it will add it to the device with the default mechanism.
+
+      // Safe to pass null credentials here, as jclouds will default populate
+      // the node with the default credentials from the image, or the ones in
+      // the options, if provided.
+      return new NodeAndInitialCredentials<Device>(device, device.id(), null);
+   }
+
+   @Override
+   public Iterable<Plan> listHardwareProfiles() {
+      return Iterables.filter(api.planApi().list().concat(), new Predicate<Plan>() {
+         @Override
+         public boolean apply(Plan input) {
+            return input.line().equals("baremetal");
+         }
+      });
+   }
+
+   @Override
+   public Iterable<OperatingSystem> listImages() {
+      return api.operatingSystemApi().list().concat();
+   }
+
+   @Override
+   public OperatingSystem getImage(final String id) {
+      Optional<OperatingSystem> firstInterestingOperatingSystem = api
+              .operatingSystemApi().list()
+              .concat()
+              .firstMatch(new Predicate<OperatingSystem>() {
+                 @Override
+                 public boolean apply(OperatingSystem input) {
+                    return input.slug().equals(id);
+                 }
+              });
+      if (!firstInterestingOperatingSystem.isPresent()) {
+         throw new IllegalStateException("Cannot find image with the required slug " + id);
+      }
+      return firstInterestingOperatingSystem.get();
+   }
+
+   @Override
+   public Iterable<Facility> listLocations() {
+      return api.facilityApi().list().concat();
+   }
+
+   @Override
+   public Device getNode(String id) {
+      return api.deviceApi(projectId).get(id);
+   }
+
+   @Override
+   public void destroyNode(String id) {
+      api.deviceApi(projectId).delete(id);
+   }
+
+   @Override
+   public void rebootNode(String id) {
+      api.deviceApi(projectId).reboot(id);
+   }
+
+   @Override
+   public void resumeNode(String id) {
+      api.deviceApi(projectId).powerOn(id);
+   }
+
+   @Override
+   public void suspendNode(String id) {
+      api.deviceApi(projectId).powerOff(id);
+   }
+
+   @Override
+   public Iterable<Device> listNodes() {
+     return api.deviceApi(projectId).list().concat();
+   }
+
+   @Override
+   public Iterable<Device> listNodesByIds(final Iterable<String> ids) {
+      return filter(listNodes(), new Predicate<Device>() {
+         @Override
+         public boolean apply(Device device) {
+            return contains(ids, String.valueOf(device.id()));
+         }
+      });
+   }
+
+}

--- a/packet/src/main/java/org/jclouds/packet/compute/config/PacketComputeServiceContextModule.java
+++ b/packet/src/main/java/org/jclouds/packet/compute/config/PacketComputeServiceContextModule.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.compute.config;
+
+import org.jclouds.compute.ComputeServiceAdapter;
+import org.jclouds.compute.config.ComputeServiceAdapterContextModule;
+import org.jclouds.compute.domain.Hardware;
+import org.jclouds.compute.domain.Image;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.compute.strategy.CreateNodesInGroupThenAddToSet;
+import org.jclouds.domain.Credentials;
+import org.jclouds.domain.Location;
+import org.jclouds.location.Provider;
+import org.jclouds.packet.PacketApi;
+import org.jclouds.packet.compute.PacketComputeServiceAdapter;
+import org.jclouds.packet.compute.functions.DeviceStateToStatus;
+import org.jclouds.packet.compute.functions.DeviceToNodeMetadata;
+import org.jclouds.packet.compute.functions.FacilityToLocation;
+import org.jclouds.packet.compute.functions.OperatingSystemToImage;
+import org.jclouds.packet.compute.functions.PlanToHardware;
+import org.jclouds.packet.compute.options.PacketTemplateOptions;
+import org.jclouds.packet.compute.strategy.CreateSshKeysThenCreateNodes;
+import org.jclouds.packet.domain.Device;
+import org.jclouds.packet.domain.Facility;
+import org.jclouds.packet.domain.OperatingSystem;
+import org.jclouds.packet.domain.Plan;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.inject.Provides;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Named;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
+import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
+import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_TERMINATED;
+import static org.jclouds.util.Predicates2.retry;
+
+public class PacketComputeServiceContextModule extends
+        ComputeServiceAdapterContextModule<Device, Plan, OperatingSystem, Facility> {
+
+   @SuppressWarnings("unchecked")
+   @Override
+   protected void configure() {
+      super.configure();
+
+      bind(new TypeLiteral<ComputeServiceAdapter<Device, Plan, OperatingSystem, Facility>>() {
+      }).to(PacketComputeServiceAdapter.class);
+
+      bind(new TypeLiteral<Function<Device, NodeMetadata>>() {
+      }).to(DeviceToNodeMetadata.class);
+      bind(new TypeLiteral<Function<Plan, Hardware>>() {
+      }).to(PlanToHardware.class);
+      bind(new TypeLiteral<Function<OperatingSystem, Image>>() {
+      }).to(OperatingSystemToImage.class);
+      bind(new TypeLiteral<Function<Facility, Location>>() {
+      }).to(FacilityToLocation.class);
+      bind(new TypeLiteral<Function<Device.State, NodeMetadata.Status>>() {
+      }).to(DeviceStateToStatus.class);
+      install(new LocationsFromComputeServiceAdapterModule<Device, Plan, OperatingSystem, Facility>() {
+      });
+      bind(TemplateOptions.class).to(PacketTemplateOptions.class);
+      bind(CreateNodesInGroupThenAddToSet.class).to(CreateSshKeysThenCreateNodes.class);
+   }
+
+   @Provides
+   @Named(TIMEOUT_NODE_RUNNING)
+   protected Predicate<String> provideDeviceRunningPredicate(final PacketApi api,
+                                                             @Provider final Supplier<Credentials> creds,
+                                                             ComputeServiceConstants.Timeouts timeouts,
+                                                             ComputeServiceConstants.PollPeriod pollPeriod) {
+      return retry(new DeviceInStatusPredicate(api, creds.get().identity, Device.State.ACTIVE), timeouts.nodeRunning,
+              pollPeriod.pollInitialPeriod, pollPeriod.pollMaxPeriod);
+   }
+
+   @Provides
+   @Named(TIMEOUT_NODE_SUSPENDED)
+   protected Predicate<String> provideDeviceSuspendedPredicate(final PacketApi api, @Provider final Supplier<Credentials> creds, ComputeServiceConstants.Timeouts timeouts,
+                                                                 ComputeServiceConstants.PollPeriod pollPeriod) {
+      return retry(new DeviceInStatusPredicate(api, creds.get().identity, Device.State.INACTIVE), timeouts.nodeSuspended,
+              pollPeriod.pollInitialPeriod, pollPeriod.pollMaxPeriod);
+   }
+   
+   @Provides
+   @Named(TIMEOUT_NODE_TERMINATED)
+   protected Predicate<String> provideDeviceTerminatedPredicate(final PacketApi api, @Provider final Supplier<Credentials> creds, ComputeServiceConstants.Timeouts timeouts,
+                                                                 ComputeServiceConstants.PollPeriod pollPeriod) {
+      return retry(new DeviceTerminatedPredicate(api, creds.get().identity), timeouts.nodeTerminated, pollPeriod.pollInitialPeriod,
+              pollPeriod.pollMaxPeriod);
+   }
+
+   @VisibleForTesting
+   static class DeviceInStatusPredicate implements Predicate<String> {
+
+      private final PacketApi api;
+      private final String projectId;
+      private final Device.State state;
+
+      public DeviceInStatusPredicate(PacketApi api, String projectId, Device.State state) {
+         this.api = checkNotNull(api, "api must not be null");
+         this.projectId = checkNotNull(projectId, "projectId must not be null");
+         this.state = checkNotNull(state, "state must not be null");
+      }
+
+      @Override
+      public boolean apply(String input) {
+         checkNotNull(input, "device id");
+         Device device = api.deviceApi(projectId).get(input);
+         return device != null && state == device.state();
+      }
+   }
+
+   @VisibleForTesting
+   static class DeviceTerminatedPredicate implements Predicate<String> {
+
+      private final PacketApi api;
+      private final String projectId;
+
+      public DeviceTerminatedPredicate(PacketApi api, String projectId) {
+         this.api = checkNotNull(api, "api must not be null");
+         this.projectId = checkNotNull(projectId, "projectId must not be null");
+      }
+
+      @Override
+      public boolean apply(String input) {
+         checkNotNull(input, "device id");
+         Device device = api.deviceApi(projectId).get(input);
+         return device == null;
+      }
+   }
+
+}

--- a/packet/src/main/java/org/jclouds/packet/compute/functions/DeviceStateToStatus.java
+++ b/packet/src/main/java/org/jclouds/packet/compute/functions/DeviceStateToStatus.java
@@ -33,8 +33,13 @@ public class DeviceStateToStatus implements Function<Device.State, Status> {
 
    private static final Function<Device.State, Status> toPortableStatus = Functions.forMap(
          ImmutableMap.<Device.State, Status> builder()
-               .put(Device.State.PROVISIONING, Status.PENDING)
-               .put(Device.State.ACTIVE, Status.RUNNING)
+                 .put(Device.State.PROVISIONING, Status.PENDING)
+                 .put(Device.State.POWERING_ON, Status.PENDING)
+                 .put(Device.State.POWERING_OFF, Status.PENDING)
+                 .put(Device.State.REBOOTING, Status.PENDING)
+                 .put(Device.State.QUEUED, Status.PENDING)
+                 .put(Device.State.INACTIVE, Status.SUSPENDED)
+                 .put(Device.State.ACTIVE, Status.RUNNING)
                .build(),
          Status.UNRECOGNIZED);
 

--- a/packet/src/main/java/org/jclouds/packet/compute/functions/DeviceToNodeMetadata.java
+++ b/packet/src/main/java/org/jclouds/packet/compute/functions/DeviceToNodeMetadata.java
@@ -69,7 +69,7 @@ public class DeviceToNodeMetadata implements Function<Device, NodeMetadata> {
       return new NodeMetadataBuilder()
               .ids(input.id())
               .name(input.hostname())
-              .hostname(input.hostname())
+              .hostname(String.format("%s", input.hostname()))  
               .group(groupNamingConvention.extractGroup(input.hostname()))
               .location(facilityToLocation.apply(input.facility()))
               .hardware(planToHardware.apply(input.plan()))

--- a/packet/src/main/java/org/jclouds/packet/compute/options/PacketTemplateOptions.java
+++ b/packet/src/main/java/org/jclouds/packet/compute/options/PacketTemplateOptions.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.compute.options;
+
+import java.util.Map;
+
+import org.jclouds.compute.options.TemplateOptions;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.collect.ImmutableMap;
+
+import static com.google.common.base.Objects.equal;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Custom options for the Packet API.
+ */
+public class PacketTemplateOptions extends TemplateOptions implements Cloneable {
+
+   private Map<String, String> features = ImmutableMap.of();
+   private boolean locked = false;
+   private String billingCycle = "hourly";
+   private String userData = "";
+
+   public PacketTemplateOptions features(Map<String, String> features) {
+      this.features = ImmutableMap.copyOf(checkNotNull(features, "features cannot be null"));
+      return this;
+   }
+   
+   public PacketTemplateOptions locked(boolean locked) {
+      this.locked = locked;
+      return this;
+   }
+
+   public PacketTemplateOptions billingCycle(String billingCycle) {
+      this.billingCycle = billingCycle;
+      return this;
+   }
+   
+   public PacketTemplateOptions userData(String userData) {
+      this.userData = userData;
+      return this;
+   }
+
+   public Map<String, String> getFeatures() {
+      return features;
+   }
+   public boolean isLocked() {
+      return locked;
+   }
+   public String getBillingCycle() {
+      return billingCycle;
+   }
+   public String getUserData() {
+      return userData;
+   }
+
+   @Override
+   public PacketTemplateOptions clone() {
+      PacketTemplateOptions options = new PacketTemplateOptions();
+      copyTo(options);
+      return options;
+   }
+
+   @Override
+   public void copyTo(TemplateOptions to) {
+      super.copyTo(to);
+      if (to instanceof PacketTemplateOptions) {
+         PacketTemplateOptions eTo = PacketTemplateOptions.class.cast(to);
+         eTo.features(features);
+         eTo.locked(locked);
+         eTo.billingCycle(billingCycle);
+         eTo.userData(userData);
+      }
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(super.hashCode(), features, locked, billingCycle, userData);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!super.equals(obj)) {
+         return false;
+      }
+      if (getClass() != obj.getClass()) {
+         return false;
+      }
+      PacketTemplateOptions other = (PacketTemplateOptions) obj;
+      return super.equals(other) && equal(this.locked, other.locked) && equal(this.billingCycle, other.billingCycle) && equal(this.userData, other.userData) && equal(this.features, other.features);
+   }
+
+   @Override
+   public ToStringHelper string() {
+      ToStringHelper toString = super.string().omitNullValues();
+      if (!features.isEmpty()) {
+         toString.add("features", features);
+      }      toString.add("locked", locked);
+      toString.add("billingCycle", billingCycle);
+      toString.add("userData", userData);
+      return toString;
+   }
+
+   public static class Builder {
+
+      /**
+       * @see PacketTemplateOptions#features
+       */
+      public static PacketTemplateOptions features(Map<String, String> features) {
+         PacketTemplateOptions options = new PacketTemplateOptions();
+         return options.features(features);
+      }
+      
+      /**
+       * @see PacketTemplateOptions#locked
+       */
+      public static PacketTemplateOptions locked(boolean locked) {
+         PacketTemplateOptions options = new PacketTemplateOptions();
+         return options.locked(locked);
+      }
+
+      /**
+       * @see PacketTemplateOptions#billingCycle
+       */
+      public static PacketTemplateOptions billingCycle(String billingCycle) {
+         PacketTemplateOptions options = new PacketTemplateOptions();
+         return options.billingCycle(billingCycle);
+      }
+      
+      /**
+       * @see PacketTemplateOptions#userData
+       */
+      public static PacketTemplateOptions userData(String userData) {
+         PacketTemplateOptions options = new PacketTemplateOptions();
+         return options.userData(userData);
+      }
+
+   }
+}

--- a/packet/src/main/java/org/jclouds/packet/compute/strategy/CreateSshKeysThenCreateNodes.java
+++ b/packet/src/main/java/org/jclouds/packet/compute/strategy/CreateSshKeysThenCreateNodes.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.compute.strategy;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jclouds.Constants;
+import org.jclouds.compute.config.CustomizationResponse;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.functions.GroupNamingConvention;
+import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.compute.strategy.CreateNodeWithGroupEncodedIntoName;
+import org.jclouds.compute.strategy.CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap;
+import org.jclouds.compute.strategy.ListNodesStrategy;
+import org.jclouds.compute.strategy.impl.CreateNodesWithGroupEncodedIntoNameThenAddToSet;
+import org.jclouds.logging.Logger;
+import org.jclouds.packet.PacketApi;
+import org.jclouds.packet.compute.options.PacketTemplateOptions;
+import org.jclouds.packet.domain.SshKey;
+import org.jclouds.ssh.SshKeyPairGenerator;
+import org.jclouds.ssh.SshKeys;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.propagate;
+import static com.google.common.collect.Iterables.get;
+import static com.google.common.collect.Iterables.size;
+
+@Singleton
+public class CreateSshKeysThenCreateNodes extends CreateNodesWithGroupEncodedIntoNameThenAddToSet {
+
+    @Resource
+    @Named(ComputeServiceConstants.COMPUTE_LOGGER)
+    protected Logger logger = Logger.NULL;
+
+    private final PacketApi api;
+    private final SshKeyPairGenerator keyGenerator;
+
+    @Inject
+    protected CreateSshKeysThenCreateNodes(
+            CreateNodeWithGroupEncodedIntoName addNodeWithGroupStrategy,
+            ListNodesStrategy listNodesStrategy,
+            GroupNamingConvention.Factory namingConvention,
+            @Named(Constants.PROPERTY_USER_THREADS) ListeningExecutorService userExecutor,
+            CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.Factory customizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapFactory,
+            PacketApi api, SshKeyPairGenerator keyGenerator) {
+        super(addNodeWithGroupStrategy, listNodesStrategy, namingConvention, userExecutor,
+                customizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapFactory);
+        this.api = api;
+        this.keyGenerator = keyGenerator;
+    }
+
+    @Override
+    public Map<?, ListenableFuture<Void>> execute(String group, int count, Template template,
+                                                  Set<NodeMetadata> goodNodes, Map<NodeMetadata, Exception> badNodes,
+                                                  Multimap<NodeMetadata, CustomizationResponse> customizationResponses) {
+
+        PacketTemplateOptions options = template.getOptions().as(PacketTemplateOptions.class);
+        Set<String> generatedSshKeyIds = Sets.newHashSet();
+
+        // If no key has been configured, generate a key pair
+        if (Strings.isNullOrEmpty(options.getPublicKey())) {
+            generateKeyPairAndAddKeyToSet(options, generatedSshKeyIds, group);
+        }
+
+        // If there is a script to run in the node, make sure a private key has
+        // been configured so jclouds will be able to access the node
+        if (options.getRunScript() != null && Strings.isNullOrEmpty(options.getLoginPrivateKey())) {
+            logger.warn(">> A runScript has been configured but no SSH key has been provided."
+                    + " Authentication will delegate to the ssh-agent");
+        }
+
+        // If there is a key configured, then make sure there is a key pair for it
+        if (!Strings.isNullOrEmpty(options.getPublicKey())) {
+            createKeyPairForPublicKeyInOptionsAndAddToSet(options, generatedSshKeyIds);
+        }
+
+        Map<?, ListenableFuture<Void>> responses = super.execute(group, count, template, goodNodes, badNodes,
+                customizationResponses);
+
+        // Key pairs in Packet are only required to create the devices. They aren't used anymore so it is better
+        // to delete the auto-generated key pairs at this point where we know exactly which ones have been
+        // auto-generated by jclouds.
+        registerAutoGeneratedKeyPairCleanupCallbacks(responses, generatedSshKeyIds);
+
+        return responses;
+    }
+
+    private void createKeyPairForPublicKeyInOptionsAndAddToSet(PacketTemplateOptions options,
+                                                               Set<String> generatedSshKeyIds) {
+        logger.debug(">> checking if the key pair already exists...");
+
+        PublicKey userKey;
+        Iterable<String> parts = Splitter.on(' ').split(options.getPublicKey());
+        checkArgument(size(parts) >= 2, "bad format, should be: ssh-rsa AAAAB3...");
+        String type = get(parts, 0);
+
+        try {
+            if ("ssh-rsa".equals(type)) {
+                RSAPublicKeySpec spec = SshKeys.publicKeySpecFromOpenSSH(options.getPublicKey());
+                userKey = KeyFactory.getInstance("RSA").generatePublic(spec);
+            } else {
+                throw new IllegalArgumentException("bad format, ssh-rsa is only supported");
+            }
+        } catch (InvalidKeySpecException ex) {
+            throw propagate(ex);
+        } catch (NoSuchAlgorithmException ex) {
+            throw propagate(ex);
+        }
+      String label = computeFingerprint(userKey);
+      SshKey key = api.sshKeyApi().get(label);
+
+      if (key == null) {
+         logger.debug(">> key pair not found. creating a new key pair %s ...", label);
+         SshKey newKey = api.sshKeyApi().create(label, options.getPublicKey());
+         logger.debug(">> key pair created! %s", newKey);
+      } else {
+         logger.debug(">> key pair found! %s", key);
+         generatedSshKeyIds.add(key.id());
+      }
+    }
+
+    private void generateKeyPairAndAddKeyToSet(PacketTemplateOptions options, Set<String> generatedSshKeyIds, String prefix) {
+        logger.debug(">> creating default keypair for node...");
+
+        Map<String, String> defaultKeys = keyGenerator.get();
+
+        SshKey sshKey = api.sshKeyApi().create(prefix + System.getProperty("user.name"), defaultKeys.get("public"));
+        generatedSshKeyIds.add(sshKey.id());
+        logger.debug(">> keypair created! %s", sshKey);
+
+        // If a private key has not been explicitly set, configure the generated one
+        if (Strings.isNullOrEmpty(options.getLoginPrivateKey())) {
+            options.overrideLoginPrivateKey(defaultKeys.get("private"));
+        }
+    }
+
+    private void registerAutoGeneratedKeyPairCleanupCallbacks(Map<?, ListenableFuture<Void>> responses,
+                                                              final Set<String> generatedSshKeyIds) {
+        // The Futures.allAsList fails immediately if some of the futures fail. The Futures.successfulAsList, however,
+        // returns a list containing the results or 'null' for those futures that failed. We want to wait for all them
+        // (even if they fail), so better use the latter form.
+        ListenableFuture<List<Void>> aggregatedResponses = Futures.successfulAsList(responses.values());
+
+        // Key pairs must be cleaned up after all futures completed (even if some failed).
+        Futures.addCallback(aggregatedResponses, new FutureCallback<List<Void>>() {
+            @Override
+            public void onSuccess(List<Void> result) {
+                cleanupAutoGeneratedKeyPairs(generatedSshKeyIds);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                cleanupAutoGeneratedKeyPairs(generatedSshKeyIds);
+            }
+
+            private void cleanupAutoGeneratedKeyPairs(Set<String> generatedSshKeyIds) {
+                logger.debug(">> cleaning up auto-generated key pairs...");
+                for (String sshKeyId : generatedSshKeyIds) {
+                    try {
+                        api.sshKeyApi().delete(sshKeyId);
+                    } catch (Exception ex) {
+                        logger.warn(">> could not delete key pair %s: %s", sshKeyId, ex.getMessage());
+                    }
+                }
+            }
+        }, userExecutor);
+    }
+
+    private static String computeFingerprint(PublicKey key) {
+        if (key instanceof RSAPublicKey) {
+            RSAPublicKey rsaKey = (RSAPublicKey) key;
+            return SshKeys.fingerprint(rsaKey.getPublicExponent(), rsaKey.getModulus());
+        } else {
+            throw new IllegalArgumentException("Only RSA keys are supported");
+        }
+    }
+
+}

--- a/packet/src/main/java/org/jclouds/packet/domain/Device.java
+++ b/packet/src/main/java/org/jclouds/packet/domain/Device.java
@@ -38,7 +38,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public abstract class Device {
 
     public enum State {
-        PROVISIONING, QUEUED, ACTIVE;
+        PROVISIONING, QUEUED, ACTIVE, REBOOTING, POWERING_OFF, POWERING_ON, INACTIVE;
 
         public static State fromValue(String value) {
             Optional<State> state = Enums.getIfPresent(State.class, value.toUpperCase());

--- a/packet/src/main/java/org/jclouds/packet/features/DeviceApi.java
+++ b/packet/src/main/java/org/jclouds/packet/features/DeviceApi.java
@@ -40,7 +40,6 @@ import org.jclouds.http.functions.ParseJson;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.Json;
 import org.jclouds.packet.PacketApi;
-import org.jclouds.packet.domain.ActionType;
 import org.jclouds.packet.domain.Device;
 import org.jclouds.packet.domain.Href;
 import org.jclouds.packet.domain.internal.PaginatedCollection;
@@ -49,8 +48,7 @@ import org.jclouds.packet.filters.AddApiVersionToRequest;
 import org.jclouds.packet.filters.AddXAuthTokenToRequest;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
-import org.jclouds.rest.annotations.MapBinder;
-import org.jclouds.rest.annotations.PayloadParam;
+import org.jclouds.rest.annotations.Payload;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.Transform;
@@ -60,13 +58,13 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.inject.TypeLiteral;
 
-@Path("/projects/{projectId}/devices")
 @Consumes(MediaType.APPLICATION_JSON)
 @RequestFilters({AddXAuthTokenToRequest.class, AddApiVersionToRequest.class})
 public interface DeviceApi {
 
    @Named("device:list")
    @GET
+   @Path("/projects/{projectId}/devices")
    @ResponseParser(ParseDevices.class)
    @Transform(ParseDevices.ToPagedIterable.class)
    @Fallback(Fallbacks.EmptyPagedIterableOnNotFoundOr404.class)
@@ -74,6 +72,7 @@ public interface DeviceApi {
 
    @Named("device:list")
    @GET
+   @Path("/projects/{projectId}/devices")
    @ResponseParser(ParseDevices.class)
    @Fallback(Fallbacks.EmptyIterableWithMarkerOnNotFoundOr404.class)
    IterableWithMarker<Device> list(ListOptions options);
@@ -122,27 +121,43 @@ public interface DeviceApi {
 
    @Named("device:create")
    @POST
+   @Path("/projects/{projectId}/devices")
    @Produces(MediaType.APPLICATION_JSON)
    Device create(@BinderParam(BindToJsonPayload.class) Device.CreateDevice device);
 
 
    @Named("device:get")
    @GET
-   @Path("/{id}")
+   @Path("/devices/{id}")
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    Device get(@PathParam("id") String id);
 
    @Named("device:delete")
    @DELETE
-   @Path("/{id}")
+   @Path("/devices/{id}")
    @Fallback(VoidOnNotFoundOr404.class)
    void delete(@PathParam("id") String id);
 
-   @Named("device:actions")
+   @Named("device:powerOff")
    @POST
-   @Path("/{id}/actions")
-   @MapBinder(BindToJsonPayload.class)
-   void actions(@PathParam("id") String id, @PayloadParam("type") ActionType type);
+   @Produces(MediaType.APPLICATION_JSON)
+   @Path("/devices/{id}/actions")
+   @Payload("{\"type\":\"power_off\"}")
+   void powerOff(@PathParam("id") String id);
+
+   @Named("device:powerOn")
+   @POST
+   @Produces(MediaType.APPLICATION_JSON)
+   @Path("/devices/{id}/actions")
+   @Payload("{\"type\":\"power_on\"}")
+   void powerOn(@PathParam("id") String id);
+   
+   @Named("device:reboot")
+   @POST
+   @Produces(MediaType.APPLICATION_JSON)
+   @Path("/devices/{id}/actions")
+   @Payload("{\"type\":\"reboot\"}")
+   void reboot(@PathParam("id") String id);
 
 }

--- a/packet/src/test/java/org/jclouds/packet/compute/PacketComputeProviderMetadataTest.java
+++ b/packet/src/test/java/org/jclouds/packet/compute/PacketComputeProviderMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.compute;
+
+import org.jclouds.packet.PacketApiMetadata;
+import org.jclouds.packet.PacketProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadataTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "PacketComputeProviderMetadataTest")
+public class PacketComputeProviderMetadataTest extends BaseProviderMetadataTest {
+
+   public PacketComputeProviderMetadataTest() {
+      super(new PacketProviderMetadata(), new PacketApiMetadata());
+   }
+}

--- a/packet/src/test/java/org/jclouds/packet/compute/PacketComputeServiceLiveTest.java
+++ b/packet/src/test/java/org/jclouds/packet/compute/PacketComputeServiceLiveTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.compute;
+
+import java.util.Properties;
+
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.internal.BaseComputeServiceLiveTest;
+import org.jclouds.rest.AuthorizationException;
+import org.jclouds.sshj.config.SshjSshClientModule;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+/**
+ * Live tests for the {@link org.jclouds.compute.ComputeService} integration.
+ */
+@Test(groups = "live", singleThreaded = true, testName = "PacketComputeServiceLiveTest")
+public class PacketComputeServiceLiveTest extends BaseComputeServiceLiveTest {
+
+   public PacketComputeServiceLiveTest() {
+      provider = "packet";
+   }
+
+   @Override
+   protected Module getSshModule() {
+      return new SshjSshClientModule();
+   }
+
+   @Override
+   @Test(expectedExceptions = AuthorizationException.class)
+   public void testCorrectAuthException() throws Exception {
+      ComputeServiceContext context = null;
+      try {
+         Properties overrides = setupProperties();
+         overrides.setProperty(provider + ".identity", "MOM:MA");
+         overrides.setProperty(provider + ".credential", "MIA");
+         context = newBuilder()
+                 .modules(ImmutableSet.of(getLoggingModule(), credentialStoreModule))
+                 .overrides(overrides)
+                 .build(ComputeServiceContext.class);
+         // replace listNodes with listImages as it doesn't require `projectId`
+         context.getComputeService().listImages();
+      } catch (AuthorizationException e) {
+         throw e;
+      } catch (RuntimeException e) {
+         e.printStackTrace();
+         throw e;
+      } finally {
+         if (context != null)
+            context.close();
+      }
+   }
+
+   @Override
+   public void testOptionToNotBlock() throws Exception {
+      // Packet ComputeService implementation has to block until the node
+      // is provisioned, to be able to return it.
+   }
+
+   @Override
+   protected void checkUserMetadataContains(NodeMetadata node, ImmutableMap<String, String> userMetadata) {
+      // The Packet API does not return the user data
+   }
+
+}

--- a/packet/src/test/java/org/jclouds/packet/compute/PacketTemplateBuilderLiveTest.java
+++ b/packet/src/test/java/org/jclouds/packet/compute/PacketTemplateBuilderLiveTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.packet.compute;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.jclouds.compute.domain.OsFamily;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.internal.BaseTemplateBuilderLiveTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "live", testName = "PacketTemplateBuilderLiveTest")
+public class PacketTemplateBuilderLiveTest extends BaseTemplateBuilderLiveTest {
+
+   public PacketTemplateBuilderLiveTest() {
+      provider = "packet";
+   }
+
+   @Test
+   @Override
+   public void testDefaultTemplateBuilder() throws IOException {
+      Template defaultTemplate = view.getComputeService().templateBuilder().build();
+      assert defaultTemplate.getImage().getOperatingSystem().getVersion().startsWith("16.") : defaultTemplate
+            .getImage().getOperatingSystem().getVersion();
+      assertEquals(defaultTemplate.getImage().getOperatingSystem().is64Bit(), true);
+      assertEquals(defaultTemplate.getImage().getOperatingSystem().getFamily(), OsFamily.UBUNTU);
+      assertEquals(getCores(defaultTemplate.getHardware()), 1.0d);
+   }
+
+   @Override
+   protected Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US-CA", "US-NJ", "NL", "JP");
+   }
+
+}

--- a/packet/src/test/java/org/jclouds/packet/compute/internal/BasePacketApiLiveTest.java
+++ b/packet/src/test/java/org/jclouds/packet/compute/internal/BasePacketApiLiveTest.java
@@ -31,12 +31,14 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
+import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_TERMINATED;
 import static org.testng.Assert.assertTrue;
 
 public class BasePacketApiLiveTest extends BaseApiLiveTest<PacketApi> {
 
    private Predicate<String> deviceRunning;
+   private Predicate<String> deviceSuspended;
    private Predicate<String> deviceTerminated;
 
    public BasePacketApiLiveTest() {
@@ -57,6 +59,8 @@ public class BasePacketApiLiveTest extends BaseApiLiveTest<PacketApi> {
       Injector injector = newBuilder().modules(modules).overrides(props).buildInjector();
       deviceRunning = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>(){},
             Names.named(TIMEOUT_NODE_RUNNING)));
+      deviceSuspended = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>(){},
+              Names.named(TIMEOUT_NODE_SUSPENDED)));
       deviceTerminated = injector.getInstance(Key.get(new TypeLiteral<Predicate<String>>(){},
               Names.named(TIMEOUT_NODE_TERMINATED)));
       return injector.getInstance(PacketApi.class);
@@ -66,6 +70,10 @@ public class BasePacketApiLiveTest extends BaseApiLiveTest<PacketApi> {
       assertTrue(deviceRunning.apply(deviceId), String.format("Device %s did not start in the configured timeout", deviceId));
    }
 
+   protected void assertNodeSuspended(String deviceId) {
+      assertTrue(deviceSuspended.apply(deviceId), String.format("Device %s was not suspended in the configured timeout", deviceId));
+   }
+   
    protected void assertNodeTerminated(String deviceId) {
       assertTrue(deviceTerminated.apply(deviceId), String.format("Device %s was not terminated in the configured timeout", deviceId));
    }

--- a/packet/src/test/java/org/jclouds/packet/features/DeviceApiLiveTest.java
+++ b/packet/src/test/java/org/jclouds/packet/features/DeviceApiLiveTest.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jclouds.packet.compute.internal.BasePacketApiLiveTest;
-import org.jclouds.packet.domain.ActionType;
 import org.jclouds.packet.domain.BillingCycle;
 import org.jclouds.packet.domain.Device;
 import org.jclouds.packet.domain.SshKey;
@@ -40,7 +39,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.util.Strings.isNullOrEmpty;
 
-@Test(groups = "live", testName = "DeviceApiLiveTest")
+@Test(groups = "live", singleThreaded = true, testName = "DeviceApiLiveTest")
 public class DeviceApiLiveTest extends BasePacketApiLiveTest {
 
    private SshKey sshKey;
@@ -81,22 +80,22 @@ public class DeviceApiLiveTest extends BasePacketApiLiveTest {
 
    @Test(groups = "live", dependsOnMethods = "testCreate")
    public void testReboot() {
-      api().actions(deviceId, ActionType.REBOOT);
+      api().reboot(deviceId);
       assertNodeRunning(deviceId);
    }
 
    @Test(groups = "live", dependsOnMethods = "testReboot")
    public void testPowerOff() {
-      api().actions(deviceId, ActionType.POWER_OFF);
-      assertNodeTerminated(deviceId);
+      api().powerOff(deviceId);
+      assertNodeSuspended(deviceId);
    }
 
    @Test(groups = "live", dependsOnMethods = "testPowerOff")
    public void testPowerOn() {
-      api().actions(deviceId, ActionType.POWER_ON);
+      api().powerOn(deviceId);
       assertNodeRunning(deviceId);
    }
-   
+
    @Test(dependsOnMethods = "testCreate")
    public void testList() {
       final AtomicInteger found = new AtomicInteger(0);
@@ -123,7 +122,7 @@ public class DeviceApiLiveTest extends BasePacketApiLiveTest {
       assertTrue(found.get() > 0, "Expected some devices to be returned");
    }
 
-   @Test(dependsOnMethods = "testList", alwaysRun = true)
+   @Test(dependsOnMethods = "testPowerOn", alwaysRun = true)
    public void testDelete() throws InterruptedException {
       if (deviceId != null) {
          api().delete(deviceId);

--- a/packet/src/test/java/org/jclouds/packet/features/DeviceApiMockTest.java
+++ b/packet/src/test/java/org/jclouds/packet/features/DeviceApiMockTest.java
@@ -17,7 +17,6 @@
 package org.jclouds.packet.features;
 
 import org.jclouds.packet.compute.internal.BasePacketApiMockTest;
-import org.jclouds.packet.domain.ActionType;
 import org.jclouds.packet.domain.BillingCycle;
 import org.jclouds.packet.domain.Device;
 import org.jclouds.packet.domain.Device.CreateDevice;
@@ -90,7 +89,7 @@ public class DeviceApiMockTest extends BasePacketApiMockTest {
       assertEquals(device, objectFromResource("/device.json", Device.class));
 
       assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "GET", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/1");
+      assertSent(server, "GET", "/devices/1");
    }
 
    public void testGetDeviceReturns404() throws InterruptedException {
@@ -101,7 +100,7 @@ public class DeviceApiMockTest extends BasePacketApiMockTest {
       assertNull(device);
 
       assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "GET", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/1");
+      assertSent(server, "GET", "/devices/1");
    }
 
    public void testCreateDevice() throws InterruptedException {
@@ -133,7 +132,7 @@ public class DeviceApiMockTest extends BasePacketApiMockTest {
       api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").delete("1");
 
       assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "DELETE", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/1");
+      assertSent(server, "DELETE", "/devices/1");
    }
 
    public void testDeleteDeviceReturns404() throws InterruptedException {
@@ -142,43 +141,34 @@ public class DeviceApiMockTest extends BasePacketApiMockTest {
       api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").delete("1");
 
       assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "DELETE", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/1");
+      assertSent(server, "DELETE", "/devices/1");
    }
 
    public void testActionPowerOn() throws InterruptedException {
       server.enqueue(jsonResponse("/power-on.json"));
 
-      api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").actions("deviceId", ActionType.POWER_ON);
+      api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").powerOn("deviceId");
 
       assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "POST", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/deviceId/actions");
+      assertSent(server, "POST", "/devices/deviceId/actions");
    }
 
    public void testActionPowerOff() throws InterruptedException {
       server.enqueue(jsonResponse("/power-off.json"));
 
-      api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").actions("deviceId", ActionType.POWER_OFF);
+      api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").powerOff("deviceId");
 
       assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "POST", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/deviceId/actions");
+      assertSent(server, "POST", "/devices/deviceId/actions");
    }
 
    public void testActionReboot() throws InterruptedException {
       server.enqueue(jsonResponse("/reboot.json"));
 
-      api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").actions("deviceId", ActionType.REBOOT);
+      api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").reboot("deviceId");
 
       assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "POST", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/deviceId/actions");
+      assertSent(server, "POST", "/devices/deviceId/actions");
    }
 
-   public void testActionRescue() throws InterruptedException {
-      server.enqueue(jsonResponse("/rescue.json"));
-
-      api.deviceApi("93907f48-adfe-43ed-ad89-0e6e83721a54").actions("deviceId", ActionType.RESCUE);
-
-      assertEquals(server.getRequestCount(), 1);
-      assertSent(server, "POST", "/projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices/deviceId/actions");
-   }
-   
 }

--- a/packet/src/test/java/org/jclouds/packet/features/FacilityApiLiveTest.java
+++ b/packet/src/test/java/org/jclouds/packet/features/FacilityApiLiveTest.java
@@ -18,7 +18,7 @@ package org.jclouds.packet.features;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.jclouds.packet.compute.internal.BasePacketApiMockTest;
+import org.jclouds.packet.compute.internal.BasePacketApiLiveTest;
 import org.jclouds.packet.domain.Facility;
 import org.testng.annotations.Test;
 
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.util.Strings.isNullOrEmpty;
 
 @Test(groups = "live", testName = "FacilityApiLiveTest")
-public class FacilityApiLiveTest extends BasePacketApiMockTest {
+public class FacilityApiLiveTest extends BasePacketApiLiveTest {
 
    public void testList() {
       final AtomicInteger found = new AtomicInteger(0);

--- a/packet/src/test/resources/rescue.json
+++ b/packet/src/test/resources/rescue.json
@@ -1,3 +1,0 @@
-{
-  "type": "rescue"
-}


### PR DESCRIPTION
/cc @nacx 

unit and live tests are ok
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running TestSuite
Configuring TestNG with: TestNG652Configurator
Starting test testOfApiContains(org.jclouds.packet.compute.PacketComputeProviderMetadataTest)
Starting test testWithId(org.jclouds.packet.compute.PacketComputeProviderMetadataTest)
Starting test testTransformableToContains(org.jclouds.packet.compute.PacketComputeProviderMetadataTest)
Starting test testAllContains(org.jclouds.packet.compute.PacketComputeProviderMetadataTest)
[pool-1-thread-1] Test testAllContains(org.jclouds.packet.compute.PacketComputeProviderMetadataTest) succeeded: 9ms
Test suite progress: tests succeeded: 1, failed: 0, skipped: 0.
[pool-1-thread-4] Test testWithId(org.jclouds.packet.compute.PacketComputeProviderMetadataTest) succeeded: 13ms
Test suite progress: tests succeeded: 2, failed: 0, skipped: 0.
[pool-1-thread-2] Test testOfApiContains(org.jclouds.packet.compute.PacketComputeProviderMetadataTest) succeeded: 13ms
Test suite progress: tests succeeded: 3, failed: 0, skipped: 0.
[pool-1-thread-3] Test testTransformableToContains(org.jclouds.packet.compute.PacketComputeProviderMetadataTest) succeeded: 13ms
Test suite progress: tests succeeded: 4, failed: 0, skipped: 0.
Jan 29, 2017 4:30:32 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52568] starting to accept connections
Starting test testActionPowerOff(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:32 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52568] received request: POST /devices/deviceId/actions HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-2-thread-1] Test testActionPowerOff(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 78ms
Test suite progress: tests succeeded: 5, failed: 0, skipped: 0.
Jan 29, 2017 4:30:32 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52568] done accepting connections: Socket closed
Jan 29, 2017 4:30:32 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52570] starting to accept connections
Starting test testActionPowerOn(org.jclouds.packet.features.DeviceApiMockTest)
[pool-2-thread-1] Test testActionPowerOn(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 5ms
Test suite progress: tests succeeded: 6, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52570] received request: POST /devices/deviceId/actions HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52570] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52572] starting to accept connections
Starting test testActionReboot(org.jclouds.packet.features.DeviceApiMockTest)
[pool-2-thread-1] Test testActionReboot(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 7, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52572] received request: POST /devices/deviceId/actions HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52572] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52574] starting to accept connections
Starting test testCreateDevice(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52574] received request: POST /projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-2-thread-1] Test testCreateDevice(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 66ms
Test suite progress: tests succeeded: 8, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52574] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52576] starting to accept connections
Starting test testDeleteDevice(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52576] received request: DELETE /devices/1 HTTP/1.1 and responded: HTTP/1.1 204 No Content
[pool-2-thread-1] Test testDeleteDevice(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 13ms
Test suite progress: tests succeeded: 9, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52576] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52578] starting to accept connections
Starting test testDeleteDeviceReturns404(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52578] received request: DELETE /devices/1 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-2-thread-1] Test testDeleteDeviceReturns404(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 10, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52578] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52580] starting to accept connections
Starting test testGetDevice(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52580] received request: GET /devices/1 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-2-thread-1] Test testGetDevice(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 29ms
Test suite progress: tests succeeded: 11, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52580] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52582] starting to accept connections
Starting test testGetDeviceReturns404(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52582] received request: GET /devices/1 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-2-thread-1] Test testGetDeviceReturns404(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 12, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52582] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52584] starting to accept connections
Starting test testListDevices(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52584] received request: GET /projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52584] received request: GET /projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices?page=2 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-2-thread-1] Test testListDevices(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 67ms
Test suite progress: tests succeeded: 13, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52584] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52586] starting to accept connections
Starting test testListDevicesReturns404(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52586] received request: GET /projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-2-thread-1] Test testListDevicesReturns404(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 14, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52586] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52588] starting to accept connections
Starting test testListDevicesWithOptions(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52588] received request: GET /projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-2-thread-1] Test testListDevicesWithOptions(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 39ms
Test suite progress: tests succeeded: 15, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52588] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52590] starting to accept connections
Starting test testListDevicesWithOptionsReturns404(org.jclouds.packet.features.DeviceApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52590] received request: GET /projects/93907f48-adfe-43ed-ad89-0e6e83721a54/devices?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-2-thread-1] Test testListDevicesWithOptionsReturns404(org.jclouds.packet.features.DeviceApiMockTest) succeeded: 4ms
Test suite progress: tests succeeded: 16, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52590] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52592] starting to accept connections
Starting test testListFacilities(org.jclouds.packet.features.FacilityApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52592] received request: GET /facilities HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52592] received request: GET /facilities?page=2 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-3-thread-1] Test testListFacilities(org.jclouds.packet.features.FacilityApiMockTest) succeeded: 20ms
Test suite progress: tests succeeded: 17, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52592] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52594] starting to accept connections
Starting test testListFacilitiesReturns404(org.jclouds.packet.features.FacilityApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52594] received request: GET /facilities HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-3-thread-1] Test testListFacilitiesReturns404(org.jclouds.packet.features.FacilityApiMockTest) succeeded: 10ms
Test suite progress: tests succeeded: 18, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52594] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52596] starting to accept connections
Starting test testListFacilitiesWithOptions(org.jclouds.packet.features.FacilityApiMockTest)
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52596] received request: GET /facilities?page=1&per_page=2 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-3-thread-1] Test testListFacilitiesWithOptions(org.jclouds.packet.features.FacilityApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 19, failed: 0, skipped: 0.
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52596] done accepting connections: Socket closed
Jan 29, 2017 4:30:33 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52598] starting to accept connections
Starting test testListFacilitiesWithOptionsReturns404(org.jclouds.packet.features.FacilityApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52598] received request: GET /facilities?page=1&per_page=2 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-3-thread-1] Test testListFacilitiesWithOptionsReturns404(org.jclouds.packet.features.FacilityApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 20, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52598] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52600] starting to accept connections
Starting test testListOperatingSystems(org.jclouds.packet.features.OperatingSystemApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52600] received request: GET /operating-systems HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52600] received request: GET /operating-systems?page=2 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-4-thread-1] Test testListOperatingSystems(org.jclouds.packet.features.OperatingSystemApiMockTest) succeeded: 14ms
Test suite progress: tests succeeded: 21, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52600] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52602] starting to accept connections
Starting test testListOperatingSystemsReturns404(org.jclouds.packet.features.OperatingSystemApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52602] received request: GET /operating-systems HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-4-thread-1] Test testListOperatingSystemsReturns404(org.jclouds.packet.features.OperatingSystemApiMockTest) succeeded: 3ms
Test suite progress: tests succeeded: 22, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52602] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52604] starting to accept connections
Starting test testListOperatingSystemsWithOptions(org.jclouds.packet.features.OperatingSystemApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52604] received request: GET /operating-systems?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-4-thread-1] Test testListOperatingSystemsWithOptions(org.jclouds.packet.features.OperatingSystemApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 23, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52604] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52606] starting to accept connections
Starting test testListOperatingSystemsWithOptionsReturns404(org.jclouds.packet.features.OperatingSystemApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52606] received request: GET /operating-systems?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-4-thread-1] Test testListOperatingSystemsWithOptionsReturns404(org.jclouds.packet.features.OperatingSystemApiMockTest) succeeded: 4ms
Test suite progress: tests succeeded: 24, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52606] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52608] starting to accept connections
Starting test testListPlans(org.jclouds.packet.features.PlanApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52608] received request: GET /plans HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52608] received request: GET /plans?page=2 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-5-thread-1] Test testListPlans(org.jclouds.packet.features.PlanApiMockTest) succeeded: 13ms
Test suite progress: tests succeeded: 25, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52608] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52610] starting to accept connections
Starting test testListPlansReturns404(org.jclouds.packet.features.PlanApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52610] received request: GET /plans HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-5-thread-1] Test testListPlansReturns404(org.jclouds.packet.features.PlanApiMockTest) succeeded: 2ms
Test suite progress: tests succeeded: 26, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52610] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52612] starting to accept connections
Starting test testListPlansWithOptions(org.jclouds.packet.features.PlanApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52612] received request: GET /plans?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-5-thread-1] Test testListPlansWithOptions(org.jclouds.packet.features.PlanApiMockTest) succeeded: 7ms
Test suite progress: tests succeeded: 27, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52612] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52614] starting to accept connections
Starting test testListPlansWithOptionsReturns404(org.jclouds.packet.features.PlanApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52614] received request: GET /plans?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-5-thread-1] Test testListPlansWithOptionsReturns404(org.jclouds.packet.features.PlanApiMockTest) succeeded: 3ms
Test suite progress: tests succeeded: 28, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52614] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52616] starting to accept connections
Starting test testListProjects(org.jclouds.packet.features.ProjectApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52616] received request: GET /projects HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52616] received request: GET /projects?page=2 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-6-thread-1] Test testListProjects(org.jclouds.packet.features.ProjectApiMockTest) succeeded: 17ms
Test suite progress: tests succeeded: 29, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52616] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52618] starting to accept connections
Starting test testListProjectsReturns404(org.jclouds.packet.features.ProjectApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52618] received request: GET /projects HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-6-thread-1] Test testListProjectsReturns404(org.jclouds.packet.features.ProjectApiMockTest) succeeded: 3ms
Test suite progress: tests succeeded: 30, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52618] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52620] starting to accept connections
Starting test testListProjectsWithOptions(org.jclouds.packet.features.ProjectApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52620] received request: GET /projects?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-6-thread-1] Test testListProjectsWithOptions(org.jclouds.packet.features.ProjectApiMockTest) succeeded: 8ms
Test suite progress: tests succeeded: 31, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52620] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52622] starting to accept connections
Starting test testListProjectsWithOptionsReturns404(org.jclouds.packet.features.ProjectApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52622] received request: GET /projects?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-6-thread-1] Test testListProjectsWithOptionsReturns404(org.jclouds.packet.features.ProjectApiMockTest) succeeded: 3ms
Test suite progress: tests succeeded: 32, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52622] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52624] starting to accept connections
Starting test testCreateSshKey(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52624] received request: POST /ssh-keys HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-7-thread-1] Test testCreateSshKey(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 14ms
Test suite progress: tests succeeded: 33, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52624] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52626] starting to accept connections
Starting test testDeleteSshKey(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52626] received request: DELETE /ssh-keys/1 HTTP/1.1 and responded: HTTP/1.1 204 No Content
[pool-7-thread-1] Test testDeleteSshKey(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 4ms
Test suite progress: tests succeeded: 34, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52626] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52628] starting to accept connections
Starting test testDeleteSshKeyReturns404(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52628] received request: DELETE /ssh-keys/1 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-7-thread-1] Test testDeleteSshKeyReturns404(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 3ms
Test suite progress: tests succeeded: 35, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52628] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52630] starting to accept connections
Starting test testGetSshKey(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52630] received request: GET /ssh-keys/1 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-7-thread-1] Test testGetSshKey(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 8ms
Test suite progress: tests succeeded: 36, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52630] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52632] starting to accept connections
Starting test testGetSshKeyReturns404(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52632] received request: GET /ssh-keys/1 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-7-thread-1] Test testGetSshKeyReturns404(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 3ms
Test suite progress: tests succeeded: 37, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52632] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52634] starting to accept connections
Starting test testListSshKeys(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52634] received request: GET /ssh-keys HTTP/1.1 and responded: HTTP/1.1 200 OK
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52634] received request: GET /ssh-keys?page=2 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-7-thread-1] Test testListSshKeys(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 12ms
Test suite progress: tests succeeded: 38, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52634] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52636] starting to accept connections
Starting test testListSshKeysReturns404(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52636] received request: GET /ssh-keys HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-7-thread-1] Test testListSshKeysReturns404(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 3ms
Test suite progress: tests succeeded: 39, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52636] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52638] starting to accept connections
Starting test testListSshKeysWithOptions(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52638] received request: GET /ssh-keys?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 200 OK
[pool-7-thread-1] Test testListSshKeysWithOptions(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 6ms
Test suite progress: tests succeeded: 40, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52638] done accepting connections: Socket closed
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[52640] starting to accept connections
Starting test testListSshKeysWithOptionsReturns404(org.jclouds.packet.features.SshKeyApiMockTest)
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[52640] received request: GET /ssh-keys?page=1&per_page=5 HTTP/1.1 and responded: HTTP/1.1 404 Not Found
[pool-7-thread-1] Test testListSshKeysWithOptionsReturns404(org.jclouds.packet.features.SshKeyApiMockTest) succeeded: 4ms
Test suite progress: tests succeeded: 41, failed: 0, skipped: 0.
Jan 29, 2017 4:30:34 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[52640] done accepting connections: Socket closed
Starting test testNoOptions(org.jclouds.packet.functions.HrefToListOptionsTest)
Starting test testWithOptions(org.jclouds.packet.functions.HrefToListOptionsTest)
[pool-8-thread-1] Test testNoOptions(org.jclouds.packet.functions.HrefToListOptionsTest) succeeded: 1ms
Test suite progress: tests succeeded: 42, failed: 0, skipped: 0.
[pool-8-thread-2] Test testWithOptions(org.jclouds.packet.functions.HrefToListOptionsTest) succeeded: 1ms
Test suite progress: tests succeeded: 43, failed: 0, skipped: 0.
Starting test testAllContains(org.jclouds.packet.PacketProviderMetadataTest)
Starting test testOfApiContains(org.jclouds.packet.PacketProviderMetadataTest)
Starting test testTransformableToContains(org.jclouds.packet.PacketProviderMetadataTest)
Starting test testWithId(org.jclouds.packet.PacketProviderMetadataTest)
[pool-9-thread-3] Test testTransformableToContains(org.jclouds.packet.PacketProviderMetadataTest) succeeded: 1ms
Test suite progress: tests succeeded: 44, failed: 0, skipped: 0.
[pool-9-thread-4] Test testWithId(org.jclouds.packet.PacketProviderMetadataTest) succeeded: 0ms
Test suite progress: tests succeeded: 45, failed: 0, skipped: 0.
[pool-9-thread-2] Test testOfApiContains(org.jclouds.packet.PacketProviderMetadataTest) succeeded: 1ms
Test suite progress: tests succeeded: 46, failed: 0, skipped: 0.
[pool-9-thread-1] Test testAllContains(org.jclouds.packet.PacketProviderMetadataTest) succeeded: 1ms
Test suite progress: tests succeeded: 47, failed: 0, skipped: 0.
Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.159 sec - in TestSuite

Results :

Tests run: 47, Failures: 0, Errors: 0, Skipped: 0
```
and
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Starting test testList(org.jclouds.packet.features.FacilityApiLiveTest)
Starting test testList(org.jclouds.packet.features.OperatingSystemApiLiveTest)
Starting test testCompareSizes(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest)
Starting test setServiceDefaults(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test setServiceDefaults(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 0ms
Test suite progress: tests succeeded: 1, failed: 0, skipped: 0.
Starting test testCompareSizes(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
Starting test testCreate(org.jclouds.packet.features.DeviceApiLiveTest)
[TestNG] Test testList(org.jclouds.packet.features.OperatingSystemApiLiveTest) succeeded: 2255ms
Test suite progress: tests succeeded: 2, failed: 0, skipped: 0.
[TestNG] Test testList(org.jclouds.packet.features.FacilityApiLiveTest) succeeded: 2256ms
Test suite progress: tests succeeded: 3, failed: 0, skipped: 0.
Starting test testListOnePage(org.jclouds.packet.features.OperatingSystemApiLiveTest)
Starting test testListOnePage(org.jclouds.packet.features.FacilityApiLiveTest)
[TestNG] Test testListOnePage(org.jclouds.packet.features.FacilityApiLiveTest) succeeded: 907ms
Test suite progress: tests succeeded: 4, failed: 0, skipped: 0.
[TestNG] Test testListOnePage(org.jclouds.packet.features.OperatingSystemApiLiveTest) succeeded: 934ms
Test suite progress: tests succeeded: 5, failed: 0, skipped: 0.
Starting test testList(org.jclouds.packet.features.PlanApiLiveTest)
Starting test testList(org.jclouds.packet.features.ProjectApiLiveTest)
[TestNG] Test testList(org.jclouds.packet.features.ProjectApiLiveTest) succeeded: 771ms
Test suite progress: tests succeeded: 6, failed: 0, skipped: 0.
Starting test testListOnePage(org.jclouds.packet.features.ProjectApiLiveTest)
[TestNG] Test testListOnePage(org.jclouds.packet.features.ProjectApiLiveTest) succeeded: 785ms
Test suite progress: tests succeeded: 7, failed: 0, skipped: 0.
Starting test testCreate(org.jclouds.packet.features.SshKeyApiLiveTest)
[TestNG] Test testCreate(org.jclouds.packet.features.SshKeyApiLiveTest) succeeded: 1235ms
Test suite progress: tests succeeded: 8, failed: 0, skipped: 0.
Starting test testGet(org.jclouds.packet.features.SshKeyApiLiveTest)
[TestNG] Test testGet(org.jclouds.packet.features.SshKeyApiLiveTest) succeeded: 1084ms
Test suite progress: tests succeeded: 9, failed: 0, skipped: 0.
Starting test testList(org.jclouds.packet.features.SshKeyApiLiveTest)
[TestNG] Test testList(org.jclouds.packet.features.SshKeyApiLiveTest) succeeded: 983ms
Test suite progress: tests succeeded: 10, failed: 0, skipped: 0.
Starting test testListOnePage(org.jclouds.packet.features.SshKeyApiLiveTest)
[TestNG] Test testListOnePage(org.jclouds.packet.features.SshKeyApiLiveTest) succeeded: 693ms
Test suite progress: tests succeeded: 11, failed: 0, skipped: 0.
Starting test testDelete(org.jclouds.packet.features.SshKeyApiLiveTest)
[TestNG] Test testDelete(org.jclouds.packet.features.SshKeyApiLiveTest) succeeded: 933ms
Test suite progress: tests succeeded: 12, failed: 0, skipped: 0.
[TestNG] Test testList(org.jclouds.packet.features.PlanApiLiveTest) succeeded: 7757ms
Test suite progress: tests succeeded: 13, failed: 0, skipped: 0.
Starting test testListOnePage(org.jclouds.packet.features.PlanApiLiveTest)
[TestNG] Test testCompareSizes(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest) succeeded: 11172ms
Test suite progress: tests succeeded: 14, failed: 0, skipped: 0.
Starting test testFromTemplate(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest)
[TestNG] Test testFromTemplate(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest) succeeded: 3ms
Test suite progress: tests succeeded: 15, failed: 0, skipped: 0.
Starting test testGetAssignableLocations(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest)
[TestNG] Test testGetAssignableLocations(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest) succeeded: 1ms
Test suite progress: tests succeeded: 16, failed: 0, skipped: 0.
Starting test testTemplateBuilderCanUseImageId(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest)
Jan 29, 2017 4:30:51 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest doCompareSizes
INFO: smallest {id=baremetal_0, providerId=baremetal_0, name=Type 0, processors=[{cores=1.0, speed=1.0}], ram=8192, volumes=[{id=SSD, type=LOCAL, size=80.0, bootDevice=true, durable=false}], hypervisor=none, supportsImage=ALWAYS_TRUE}
Jan 29, 2017 4:30:51 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest doCompareSizes
INFO: fastest {id=baremetal_3, providerId=baremetal_3, name=Type 3, processors=[{cores=2.0, speed=2.0}], ram=131072, volumes=[{id=SSD, type=LOCAL, size=120.0, bootDevice=true, durable=false}, {id=NVME, type=LOCAL, size=1.6, bootDevice=true, durable=false}], hypervisor=none, supportsImage=ALWAYS_TRUE}
Jan 29, 2017 4:30:51 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest doCompareSizes
INFO: biggest {id=baremetal_2, providerId=baremetal_2, name=Type 2, processors=[{cores=2.0, speed=2.0}], ram=262144, volumes=[{id=SSD, type=LOCAL, size=480.0, bootDevice=true, durable=false}], hypervisor=none, supportsImage=ALWAYS_TRUE}
[TestNG] Test testCompareSizes(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 11174ms
Test suite progress: tests succeeded: 17, failed: 0, skipped: 0.
Starting test testCorrectExceptionRunningNodesNotFound(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testCorrectExceptionRunningNodesNotFound(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 1275ms
Test suite progress: tests succeeded: 18, failed: 0, skipped: 0.
Starting test testCreateAndRunAService(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testListOnePage(org.jclouds.packet.features.PlanApiLiveTest) succeeded: 4287ms
Test suite progress: tests succeeded: 19, failed: 0, skipped: 0.
[TestNG] Test testTemplateBuilderCanUseImageId(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest) succeeded: 6657ms
Test suite progress: tests succeeded: 20, failed: 0, skipped: 0.
Starting test testTemplateBuilderWithImageIdSpecified(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest)
[TestNG] Test testTemplateBuilderWithImageIdSpecified(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest) succeeded: 12717ms
Test suite progress: tests succeeded: 21, failed: 0, skipped: 0.
Starting test testTemplateBuilderWithLoginUserSpecified(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest)
[TestNG] Test testTemplateBuilderWithLoginUserSpecified(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest) succeeded: 9833ms
Test suite progress: tests succeeded: 22, failed: 0, skipped: 0.
Starting test testDefaultTemplateBuilder(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest)
[TestNG] Test testDefaultTemplateBuilder(org.jclouds.packet.compute.PacketTemplateBuilderLiveTest) succeeded: 1ms
Test suite progress: tests succeeded: 23, failed: 0, skipped: 0.
[TestNG] Test testCreate(org.jclouds.packet.features.DeviceApiLiveTest) succeeded: 225957ms
Test suite progress: tests succeeded: 24, failed: 0, skipped: 0.
Starting test testList(org.jclouds.packet.features.DeviceApiLiveTest)
[TestNG] Test testList(org.jclouds.packet.features.DeviceApiLiveTest) succeeded: 1408ms
Test suite progress: tests succeeded: 25, failed: 0, skipped: 0.
Starting test testListOnePage(org.jclouds.packet.features.DeviceApiLiveTest)
[TestNG] Test testListOnePage(org.jclouds.packet.features.DeviceApiLiveTest) succeeded: 1376ms
Test suite progress: tests succeeded: 26, failed: 0, skipped: 0.
Starting test testReboot(org.jclouds.packet.features.DeviceApiLiveTest)
Jan 29, 2017 4:34:39 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest createAndRunAServiceInGroup
INFO: << available node(262f7f24-4601-4adf-9f11-abeb178d7e3a) os({family=ubuntu, name=Ubuntu 16.04 LTS, version=16.04, description=Ubuntu 16.04 LTS, is64Bit=true}) in 226s
[TestNG] Test testReboot(org.jclouds.packet.features.DeviceApiLiveTest) succeeded: 27677ms
Test suite progress: tests succeeded: 27, failed: 0, skipped: 0.
Starting test testPowerOff(org.jclouds.packet.features.DeviceApiLiveTest)
[TestNG] Test testPowerOff(org.jclouds.packet.features.DeviceApiLiveTest) succeeded: 12851ms
Test suite progress: tests succeeded: 28, failed: 0, skipped: 0.
Starting test testPowerOn(org.jclouds.packet.features.DeviceApiLiveTest)
[TestNG] Test testPowerOn(org.jclouds.packet.features.DeviceApiLiveTest) succeeded: 13193ms
Test suite progress: tests succeeded: 29, failed: 0, skipped: 0.
Starting test testDelete(org.jclouds.packet.features.DeviceApiLiveTest)
[TestNG] Test testDelete(org.jclouds.packet.features.DeviceApiLiveTest) succeeded: 2730ms
Test suite progress: tests succeeded: 30, failed: 0, skipped: 0.
Jan 29, 2017 4:36:14 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest createAndRunAServiceInGroup
INFO: << configured node(262f7f24-4601-4adf-9f11-abeb178d7e3a) with openjdk full version "9-internal+0-2016-04-14-195246.buildd.src" and jetty jetty-8.1.8.v20121106 in 82s
Jan 29, 2017 4:36:33 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest trackAvailabilityOfProcessOnNode
INFO: << start jetty on node(262f7f24-4601-4adf-9f11-abeb178d7e3a)[147.75.202.15:8080] [backgroundProcessMilliseconds=6854, socketOpenMilliseconds=12777]
Jan 29, 2017 4:36:48 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest trackAvailabilityOfProcessOnNode
INFO: << start jetty on node(262f7f24-4601-4adf-9f11-abeb178d7e3a)[147.75.202.15:8080] [backgroundProcessMilliseconds=6778, socketOpenMilliseconds=2004]
[TestNG] Test testCreateAndRunAService(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 360072ms
Test suite progress: tests succeeded: 31, failed: 0, skipped: 0.
Starting test testGet(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testGet(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 231677ms
Test suite progress: tests succeeded: 32, failed: 0, skipped: 0.
Starting test testGetAssignableLocations(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
Jan 29, 2017 4:40:45 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest testGetAssignableLocations
WARNING: location {scope=REGION, id=sjc1, description=Sunnyvale, CA, parent=packet}
Jan 29, 2017 4:40:45 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest testGetAssignableLocations
WARNING: location {scope=REGION, id=ewr1, description=Parsippany, NJ, parent=packet}
Jan 29, 2017 4:40:45 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest testGetAssignableLocations
WARNING: location {scope=REGION, id=ams1, description=Amsterdam, NL, parent=packet}
Jan 29, 2017 4:40:45 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest testGetAssignableLocations
WARNING: location {scope=REGION, id=nrt1, description=Tokyo, JP, parent=packet}
[TestNG] Test testGetAssignableLocations(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 991ms
Test suite progress: tests succeeded: 33, failed: 0, skipped: 0.
Starting test testImageById(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testImageById(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 4866ms
Test suite progress: tests succeeded: 34, failed: 0, skipped: 0.
Starting test testImagesCache(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testImagesCache(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 0ms
Test suite progress: tests succeeded: 35, failed: 0, skipped: 0.
Starting test testListImages(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testListImages(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 0ms
Test suite progress: tests succeeded: 36, failed: 0, skipped: 0.
Starting test testListSizes(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testListSizes(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 0ms
Test suite progress: tests succeeded: 37, failed: 0, skipped: 0.
Starting test testWeCanCancelTasks(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testWeCanCancelTasks(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 253763ms
Test suite progress: tests succeeded: 38, failed: 0, skipped: 0.
Starting test testAScriptExecutionAfterBootWithBasicTemplate(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
<< problem applying options to node(2999eb53-b882-4e33-8605-79a266ccb69d):
org.jclouds.rest.AuthorizationException: (root:pw[5d907853a9617cfd55fb62eae803595b]@147.75.202.15:22) (root:pw[5d907853a9617cfd55fb62eae803595b]@147.75.202.15:22) error acquiring {hostAndPort=147.75.202.15:22, loginUser=root, ssh=null, connectTimeout=60000, sessionTimeout=60000} (not retryable): Exhausted available authentication methods
	at org.jclouds.sshj.SshjSshClient.propagate(SshjSshClient.java:394)
	at org.jclouds.sshj.SshjSshClient.acquire(SshjSshClient.java:215)
	at org.jclouds.sshj.SshjSshClient.connect(SshjSshClient.java:224)
	at org.jclouds.compute.callables.RunScriptOnNodeUsingSsh.call(RunScriptOnNodeUsingSsh.java:74)
	at org.jclouds.compute.strategy.RunScriptOnNodeAndAddToGoodMapOrPutExceptionIntoBadMap.call(RunScriptOnNodeAndAddToGoodMapOrPutExceptionIntoBadMap.java:63)
	at org.jclouds.compute.strategy.RunScriptOnNodeAndAddToGoodMapOrPutExceptionIntoBadMap.call(RunScriptOnNodeAndAddToGoodMapOrPutExceptionIntoBadMap.java:38)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: net.schmizz.sshj.userauth.UserAuthException: Exhausted available authentication methods
	at net.schmizz.sshj.SSHClient.auth(SSHClient.java:217)
	at net.schmizz.sshj.SSHClient.auth(SSHClient.java:193)
	at net.schmizz.sshj.SSHClient.authPassword(SSHClient.java:278)
	at net.schmizz.sshj.SSHClient.authPassword(SSHClient.java:248)
	at net.schmizz.sshj.SSHClient.authPassword(SSHClient.java:232)
	at org.jclouds.sshj.SSHClientConnection.create(SSHClientConnection.java:165)
	at org.jclouds.sshj.SSHClientConnection.create(SSHClientConnection.java:49)
	at org.jclouds.sshj.SshjSshClient.acquire(SshjSshClient.java:195)
	... 8 more
[TestNG] Test testAScriptExecutionAfterBootWithBasicTemplate(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 361377ms
Test suite progress: tests succeeded: 39, failed: 0, skipped: 0.
Starting test testCorrectAuthException(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testCorrectAuthException(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 390ms
Test suite progress: tests succeeded: 40, failed: 0, skipped: 0.
Starting test testOptionToNotBlock(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testOptionToNotBlock(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 0ms
Test suite progress: tests succeeded: 41, failed: 0, skipped: 0.
Starting test testConcurrentUseOfComputeServiceToCreateNodes(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
Jan 29, 2017 4:54:59 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest$1 call
INFO: Started node 8725fc4b-df99-4fd7-a468-704fb45475b1
Jan 29, 2017 4:55:01 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest$1 call
INFO: Started node 70010b00-c682-4c37-9a31-0cddfba173b3
[TestNG] Test testConcurrentUseOfComputeServiceToCreateNodes(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 243755ms
Test suite progress: tests succeeded: 42, failed: 0, skipped: 0.
Starting test testReboot(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testReboot(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 272363ms
Test suite progress: tests succeeded: 43, failed: 0, skipped: 0.
Starting test testTemplateMatch(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testTemplateMatch(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 5860ms
Test suite progress: tests succeeded: 44, failed: 0, skipped: 0.
Starting test testSuspendResume(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testSuspendResume(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 255208ms
Test suite progress: tests succeeded: 45, failed: 0, skipped: 0.
Starting test testGetNodesWithDetails(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testGetNodesWithDetails(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 1542ms
Test suite progress: tests succeeded: 46, failed: 0, skipped: 0.
Starting test testListNodes(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testListNodes(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 1580ms
Test suite progress: tests succeeded: 47, failed: 0, skipped: 0.
Starting test testListNodesByIds(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testListNodesByIds(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 1440ms
Test suite progress: tests succeeded: 48, failed: 0, skipped: 0.
Starting test testDestroyNodes(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testDestroyNodes(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 107569ms
Test suite progress: tests succeeded: 49, failed: 0, skipped: 0.
Starting test testCreateTwoNodesWithOneSpecifiedName(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testCreateTwoNodesWithOneSpecifiedName(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 238360ms
Test suite progress: tests succeeded: 50, failed: 0, skipped: 0.
Starting test testCreateTwoNodesWithRunScript(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testCreateTwoNodesWithRunScript(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 345251ms
Test suite progress: tests succeeded: 51, failed: 0, skipped: 0.
Starting test testCreateAnotherNodeWithANewContextToEnsureSharedMemIsntRequired(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
Jan 29, 2017 5:15:39 PM org.jclouds.compute.internal.BaseComputeServiceLiveTest testCreateAnotherNodeWithANewContextToEnsureSharedMemIsntRequired
INFO: creating another node based on existing nodes' location: {scope=REGION, id=sjc1, description=Sunnyvale, CA, parent=packet}
[TestNG] Test testCreateAnotherNodeWithANewContextToEnsureSharedMemIsntRequired(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 319247ms
Test suite progress: tests succeeded: 52, failed: 0, skipped: 0.
Starting test testCredentialsCache(org.jclouds.packet.compute.PacketComputeServiceLiveTest)
[TestNG] Test testCredentialsCache(org.jclouds.packet.compute.PacketComputeServiceLiveTest) succeeded: 35ms
Test suite progress: tests succeeded: 53, failed: 0, skipped: 0.
Tests run: 53, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,025.14 sec - in TestSuite

Results :

Tests run: 53, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 50:52 min
[INFO] Finished at: 2017-01-29T17:21:07+01:00
[INFO] Final Memory: 51M/570M
[INFO] ------------------------------------------------------------------------
```