### PR TITLE
Increase Packet timeouts for node interactions

### DIFF
--- a/packet/src/main/java/org/jclouds/packet/PacketApiMetadata.java
+++ b/packet/src/main/java/org/jclouds/packet/PacketApiMetadata.java
@@ -55,8 +55,8 @@ public class PacketApiMetadata extends BaseHttpApiMetadata<PacketApi> {
    public static Properties defaultProperties() {
       Properties properties = BaseHttpApiMetadata.defaultProperties();
       properties.put(TEMPLATE, "osFamily=UBUNTU,os64Bit=true,osVersionMatches=16.*");
-      properties.put(TIMEOUT_NODE_RUNNING, 300000); // 5 mins
-      properties.put(TIMEOUT_NODE_SUSPENDED, 300000); // 5 mins
+      properties.put(TIMEOUT_NODE_RUNNING, 900000); // 15 mins
+      properties.put(TIMEOUT_NODE_SUSPENDED, 900000); // 15 mins
       return properties;
    }
 


### PR DESCRIPTION
In testing Packet provisions Ubuntu machines in 8 to 10 mins. The default timeout of 5 mins was not long enough so this PR increases that.