### PR TITLE
JCLOUDS-1273: Support multiple resource groups in ARM

### DIFF
--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/AzureComputeApi.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/AzureComputeApi.java
@@ -17,15 +17,16 @@
 package org.jclouds.azurecompute.arm;
 
 import java.io.Closeable;
+
 import javax.ws.rs.PathParam;
 
 import org.jclouds.azurecompute.arm.features.AvailabilitySetApi;
 import org.jclouds.azurecompute.arm.features.DeploymentApi;
+import org.jclouds.azurecompute.arm.features.DiskApi;
 import org.jclouds.azurecompute.arm.features.ImageApi;
 import org.jclouds.azurecompute.arm.features.JobApi;
 import org.jclouds.azurecompute.arm.features.LoadBalancerApi;
 import org.jclouds.azurecompute.arm.features.LocationApi;
-import org.jclouds.azurecompute.arm.features.DiskApi;
 import org.jclouds.azurecompute.arm.features.NetworkInterfaceCardApi;
 import org.jclouds.azurecompute.arm.features.NetworkSecurityGroupApi;
 import org.jclouds.azurecompute.arm.features.NetworkSecurityRuleApi;
@@ -47,7 +48,7 @@ import org.jclouds.rest.annotations.Delegate;
  * @see <a href="https://msdn.microsoft.com/en-us/library/azure/dn790568.aspx" >doc</a>
  */
 public interface AzureComputeApi extends Closeable {
-
+   
    /**
     * The Azure Resource Manager API includes operations for managing resource groups in your subscription.
     *
@@ -56,6 +57,9 @@ public interface AzureComputeApi extends Closeable {
    @Delegate
    ResourceGroupApi getResourceGroupApi();
 
+   /**
+    * Provides access to the Job tracking API.
+    */
    @Delegate
    JobApi getJobApi();
 

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/AzureComputeServiceAdapter.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/AzureComputeServiceAdapter.java
@@ -25,7 +25,6 @@ import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.jclouds.azurecompute.arm.compute.domain.LocationAndName.fromSlashEncoded;
 import static org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndName.fromResourceGroupAndName;
-import static org.jclouds.azurecompute.arm.compute.functions.VMImageToImage.decodeFieldsFromUniqueId;
 import static org.jclouds.azurecompute.arm.compute.functions.VMImageToImage.getMarketplacePlanFromImageMetadata;
 import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.IMAGE_PUBLISHERS;
 import static org.jclouds.azurecompute.arm.util.VMImages.isCustom;
@@ -256,7 +255,7 @@ public class AzureComputeServiceAdapter implements ComputeServiceAdapter<Virtual
 
    @Override
    public VMImage getImage(final String id) {
-      VMImage image = decodeFieldsFromUniqueId(id);
+      VMImage image = VMImage.decodeFieldsFromUniqueId(id);
 
       if (image.custom()) {
          org.jclouds.azurecompute.arm.domain.Image vmImage = api.getVirtualMachineImageApi(image.resourceGroup()).get(

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/config/AzureComputeServiceContextModule.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/config/AzureComputeServiceContextModule.java
@@ -34,7 +34,7 @@ import javax.inject.Singleton;
 import org.jclouds.azurecompute.arm.AzureComputeApi;
 import org.jclouds.azurecompute.arm.compute.AzureComputeService;
 import org.jclouds.azurecompute.arm.compute.AzureComputeServiceAdapter;
-import org.jclouds.azurecompute.arm.compute.domain.RegionAndIdAndIngressRules;
+import org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndNameAndIngressRules;
 import org.jclouds.azurecompute.arm.compute.extensions.AzureComputeImageExtension;
 import org.jclouds.azurecompute.arm.compute.extensions.AzureComputeSecurityGroupExtension;
 import org.jclouds.azurecompute.arm.compute.functions.LocationToLocation;
@@ -44,9 +44,9 @@ import org.jclouds.azurecompute.arm.compute.functions.VMHardwareToHardware;
 import org.jclouds.azurecompute.arm.compute.functions.VMImageToImage;
 import org.jclouds.azurecompute.arm.compute.functions.VirtualMachineToNodeMetadata;
 import org.jclouds.azurecompute.arm.compute.loaders.CreateSecurityGroupIfNeeded;
-import org.jclouds.azurecompute.arm.compute.loaders.ResourceGroupForLocation;
+import org.jclouds.azurecompute.arm.compute.loaders.DefaultResourceGroup;
 import org.jclouds.azurecompute.arm.compute.options.AzureTemplateOptions;
-import org.jclouds.azurecompute.arm.compute.strategy.CreateResourceGroupThenCreateNodes;
+import org.jclouds.azurecompute.arm.compute.strategy.CreateResourcesThenCreateNodes;
 import org.jclouds.azurecompute.arm.domain.Image;
 import org.jclouds.azurecompute.arm.domain.Location;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityGroup;
@@ -116,12 +116,12 @@ public class AzureComputeServiceContextModule extends
 
       bind(TemplateOptions.class).to(AzureTemplateOptions.class);
       bind(NodeAndTemplateOptionsToStatement.class).to(NodeAndTemplateOptionsToStatementWithoutPublicKey.class);
-      bind(CreateNodesInGroupThenAddToSet.class).to(CreateResourceGroupThenCreateNodes.class);
+      bind(CreateNodesInGroupThenAddToSet.class).to(CreateResourcesThenCreateNodes.class);
 
-      bind(new TypeLiteral<CacheLoader<RegionAndIdAndIngressRules, String>>() {
+      bind(new TypeLiteral<CacheLoader<ResourceGroupAndNameAndIngressRules, String>>() {
       }).to(CreateSecurityGroupIfNeeded.class);
       bind(new TypeLiteral<CacheLoader<String, ResourceGroup>>() {
-      }).to(ResourceGroupForLocation.class);
+      }).to(DefaultResourceGroup.class);
 
       bind(new TypeLiteral<ImageExtension>() {
       }).to(AzureComputeImageExtension.class);
@@ -131,14 +131,14 @@ public class AzureComputeServiceContextModule extends
 
    @Provides
    @Singleton
-   protected final LoadingCache<RegionAndIdAndIngressRules, String> securityGroupMap(
-         CacheLoader<RegionAndIdAndIngressRules, String> in) {
+   protected final LoadingCache<ResourceGroupAndNameAndIngressRules, String> securityGroupMap(
+         CacheLoader<ResourceGroupAndNameAndIngressRules, String> in) {
       return CacheBuilder.newBuilder().build(in);
    }
 
    @Provides
    @Singleton
-   protected final LoadingCache<String, ResourceGroup> resourceGroupMap(CacheLoader<String, ResourceGroup> in) {
+   protected final LoadingCache<String, ResourceGroup> defaultResourceGroup(CacheLoader<String, ResourceGroup> in) {
       return CacheBuilder.newBuilder().build(in);
    }
 

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/domain/LocationAndName.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/domain/LocationAndName.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jclouds.azurecompute.arm.domain;
+package org.jclouds.azurecompute.arm.compute.domain;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -24,27 +24,27 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 
 @AutoValue
-public abstract class RegionAndId {
+public abstract class LocationAndName {
 
-   public abstract String region();
-   public abstract String id();
+   public abstract String location();
+   public abstract String name();
    
-   protected RegionAndId() {
+   protected LocationAndName() {
       
    }
    
-   public static RegionAndId fromSlashEncoded(String id) {
+   public static LocationAndName fromSlashEncoded(String id) {
       Iterable<String> parts = Splitter.on('/').split(checkNotNull(id, "id"));
-      checkArgument(Iterables.size(parts) == 2, "id must be in format regionId/id");
-      return new AutoValue_RegionAndId(Iterables.get(parts, 0), Iterables.get(parts, 1));
+      checkArgument(Iterables.size(parts) == 2, "id must be in format location/name");
+      return new AutoValue_LocationAndName(Iterables.get(parts, 0), Iterables.get(parts, 1));
    }
 
-   public static RegionAndId fromRegionAndId(String region, String id) {
-      return new AutoValue_RegionAndId(region, id);
+   public static LocationAndName fromLocationAndName(String location, String name) {
+      return new AutoValue_LocationAndName(location, name);
    }
 
    public String slashEncode() {
-      return region() + "/" + id();
+      return location() + "/" + name();
    }
    
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/domain/ResourceGroupAndName.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/domain/ResourceGroupAndName.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azurecompute.arm.compute.domain;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+
+@AutoValue
+public abstract class ResourceGroupAndName {
+
+   public abstract String resourceGroup();
+   public abstract String name();
+   
+   protected ResourceGroupAndName() {
+      
+   }
+   
+   public static ResourceGroupAndName fromSlashEncoded(String id) {
+      Iterable<String> parts = Splitter.on('/').split(checkNotNull(id, "id"));
+      checkArgument(Iterables.size(parts) == 2, "id must be in format resourcegroup/name");
+      return new AutoValue_ResourceGroupAndName(Iterables.get(parts, 0), Iterables.get(parts, 1));
+   }
+
+   public static ResourceGroupAndName fromResourceGroupAndName(String resourceGroup, String name) {
+      return new AutoValue_ResourceGroupAndName(resourceGroup, name);
+   }
+
+   public String slashEncode() {
+      return resourceGroup() + "/" + name();
+   }
+   
+}

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/domain/ResourceGroupAndNameAndIngressRules.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/domain/ResourceGroupAndNameAndIngressRules.java
@@ -16,31 +16,36 @@
  */
 package org.jclouds.azurecompute.arm.compute.domain;
 
-import org.jclouds.azurecompute.arm.domain.RegionAndId;
+import static org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndName.fromResourceGroupAndName;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Objects;
 
 @AutoValue
-public abstract class RegionAndIdAndIngressRules {
+public abstract class ResourceGroupAndNameAndIngressRules {
 
-   abstract RegionAndId regionAndId(); // Intentionally hidden
+   abstract ResourceGroupAndName resourceGroupAndName(); // Intentionally hidden
+   
+   public abstract String location();
+
    public abstract int[] inboundPorts();
 
-   RegionAndIdAndIngressRules() {
+   ResourceGroupAndNameAndIngressRules() {
 
    }
 
-   public static RegionAndIdAndIngressRules create(String region, String id, int[] inboundPorts) {
-      return new AutoValue_RegionAndIdAndIngressRules(RegionAndId.fromRegionAndId(region, id), inboundPorts);
+   public static ResourceGroupAndNameAndIngressRules create(String resourceGroup, String location, String name,
+         int[] inboundPorts) {
+      return new AutoValue_ResourceGroupAndNameAndIngressRules(fromResourceGroupAndName(resourceGroup, name), location,
+            inboundPorts);
    }
 
-   public String id() {
-      return regionAndId().id();
+   public String name() {
+      return resourceGroupAndName().name();
    }
 
-   public String region() {
-      return regionAndId().region();
+   public String resourceGroup() {
+      return resourceGroupAndName().resourceGroup();
    }
 
    // Intentionally delegate equals and hashcode to the fields in the parent
@@ -48,7 +53,7 @@ public abstract class RegionAndIdAndIngressRules {
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(region(), id());
+      return Objects.hashCode(resourceGroup(), name());
    }
 
    @Override
@@ -56,11 +61,11 @@ public abstract class RegionAndIdAndIngressRules {
       if (obj == this) {
          return true;
       }
-      if (!(obj instanceof RegionAndId)) {
+      if (!(obj instanceof ResourceGroupAndName)) {
          return false;
       }
-      RegionAndId that = (RegionAndId) obj;
-      return Objects.equal(region(), that.region()) && Objects.equal(id(), that.id());
+      ResourceGroupAndName that = (ResourceGroupAndName) obj;
+      return Objects.equal(resourceGroup(), that.resourceGroup()) && Objects.equal(name(), that.name());
    }
 
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeImageExtension.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeImageExtension.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Functions.compose;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndName.fromSlashEncoded;
-import static org.jclouds.azurecompute.arm.compute.functions.VMImageToImage.decodeFieldsFromUniqueId;
 import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.TIMEOUT_RESOURCE_DELETED;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
 
@@ -125,7 +124,7 @@ public class AzureComputeImageExtension implements ImageExtension {
 
    @Override
    public boolean deleteImage(String id) {
-      VMImage image = decodeFieldsFromUniqueId(id);
+      VMImage image = VMImage.decodeFieldsFromUniqueId(id);
       checkArgument(image.custom(), "Only custom images can be deleted");
 
       logger.debug(">> deleting image %s", id);

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/CustomImageToVMImage.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/CustomImageToVMImage.java
@@ -16,6 +16,8 @@
  */
 package org.jclouds.azurecompute.arm.compute.functions;
 
+import static org.jclouds.azurecompute.arm.domain.IdReference.extractResourceGroup;
+
 import org.jclouds.azurecompute.arm.domain.Image;
 import org.jclouds.azurecompute.arm.domain.VMImage;
 
@@ -25,7 +27,7 @@ public class CustomImageToVMImage implements Function<Image, VMImage> {
 
    @Override
    public VMImage apply(Image input) {
-      return VMImage.customImage().customImageId(input.id()).location(input.location()).name(input.name())
+      return VMImage.customImage().resourceGroup(extractResourceGroup(input.id())).customImageId(input.id()).location(input.location()).name(input.name())
             .offer(input.properties().storageProfile().osDisk().osType()).build();
    }
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/NetworkSecurityGroupToSecurityGroup.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/NetworkSecurityGroupToSecurityGroup.java
@@ -18,8 +18,10 @@ package org.jclouds.azurecompute.arm.compute.functions;
 
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
+import static org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndName.fromResourceGroupAndName;
 import static org.jclouds.azurecompute.arm.compute.functions.NetworkSecurityRuleToIpPermission.InboundRule;
 import static org.jclouds.azurecompute.arm.compute.functions.VirtualMachineToNodeMetadata.getLocation;
+import static org.jclouds.azurecompute.arm.domain.IdReference.extractResourceGroup;
 
 import java.util.Set;
 
@@ -27,7 +29,6 @@ import javax.inject.Singleton;
 
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityGroup;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityRule;
-import org.jclouds.azurecompute.arm.domain.RegionAndId;
 import org.jclouds.collect.Memoized;
 import org.jclouds.compute.domain.SecurityGroup;
 import org.jclouds.compute.domain.SecurityGroupBuilder;
@@ -54,8 +55,8 @@ public class NetworkSecurityGroupToSecurityGroup implements Function<NetworkSecu
    public SecurityGroup apply(NetworkSecurityGroup input) {
       SecurityGroupBuilder builder = new SecurityGroupBuilder();
 
-      builder.id(RegionAndId.fromRegionAndId(input.location(), input.name()).slashEncode());
-      builder.providerId(input.properties().resourceGuid());
+      builder.id(fromResourceGroupAndName(extractResourceGroup(input.id()), input.name()).slashEncode());
+      builder.providerId(input.id());
       builder.name(input.name());
       builder.location(getLocation(locations, input.location()));
 

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/NetworkSecurityGroupToSecurityGroup.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/NetworkSecurityGroupToSecurityGroup.java
@@ -61,7 +61,7 @@ public class NetworkSecurityGroupToSecurityGroup implements Function<NetworkSecu
       builder.location(getLocation(locations, input.location()));
 
       if (input.properties().securityRules() != null) {
-         // We just supoprt security groups that allow traffic to a set of
+         // We just support security groups that allow traffic to a set of
          // targets. We don't support deny rules or origin based rules in the
          // security group api.
          builder.ipPermissions(transform(filter(input.properties().securityRules(), InboundRule), ruleToPermission));

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/TemplateToAvailabilitySet.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/TemplateToAvailabilitySet.java
@@ -29,14 +29,12 @@ import javax.inject.Singleton;
 import org.jclouds.azurecompute.arm.AzureComputeApi;
 import org.jclouds.azurecompute.arm.compute.options.AzureTemplateOptions;
 import org.jclouds.azurecompute.arm.domain.AvailabilitySet;
-import org.jclouds.azurecompute.arm.domain.ResourceGroup;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.reference.ComputeServiceConstants;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.logging.Logger;
 
 import com.google.common.base.Function;
-import com.google.common.cache.LoadingCache;
 
 @Singleton
 public class TemplateToAvailabilitySet implements Function<Template, AvailabilitySet> {
@@ -46,12 +44,10 @@ public class TemplateToAvailabilitySet implements Function<Template, Availabilit
    protected Logger logger = Logger.NULL;
 
    private final AzureComputeApi api;
-   private final LoadingCache<String, ResourceGroup> resourceGroupMap;
 
    @Inject
-   TemplateToAvailabilitySet(AzureComputeApi api, LoadingCache<String, ResourceGroup> resourceGroupMap) {
+   TemplateToAvailabilitySet(AzureComputeApi api) {
       this.api = api;
-      this.resourceGroupMap = resourceGroupMap;
    }
 
    @Nullable
@@ -62,7 +58,7 @@ public class TemplateToAvailabilitySet implements Function<Template, Availabilit
 
       AvailabilitySet availabilitySet = null;
       String location = input.getLocation().getId();
-      String resourceGroup = resourceGroupMap.getUnchecked(location).name();
+      String resourceGroup = options.getResourceGroup();
 
       if (options.getAvailabilitySetName() != null) {
          availabilitySet = api.getAvailabilitySetApi(resourceGroup).get(options.getAvailabilitySetName());

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/VMHardwareToHardware.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/VMHardwareToHardware.java
@@ -16,9 +16,10 @@
  */
 package org.jclouds.azurecompute.arm.compute.functions;
 
-import com.google.common.base.Supplier;
-import com.google.common.collect.FluentIterable;
-import com.google.inject.Inject;
+import static org.jclouds.azurecompute.arm.compute.domain.LocationAndName.fromLocationAndName;
+
+import java.util.Set;
+
 import org.jclouds.azurecompute.arm.domain.VMHardware;
 import org.jclouds.collect.Memoized;
 import org.jclouds.compute.domain.Hardware;
@@ -26,14 +27,15 @@ import org.jclouds.compute.domain.HardwareBuilder;
 import org.jclouds.compute.domain.Processor;
 import org.jclouds.compute.domain.Volume;
 import org.jclouds.compute.domain.VolumeBuilder;
-
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.jclouds.domain.Location;
 import org.jclouds.location.predicates.LocationPredicates;
 
-import java.util.Set;
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 
 public class VMHardwareToHardware implements Function<VMHardware, Hardware> {
 
@@ -49,10 +51,10 @@ public class VMHardwareToHardware implements Function<VMHardware, Hardware> {
       final HardwareBuilder builder = new HardwareBuilder()
               .name(from.name())
               .providerId(from.name())
-              .id(from.name())
+              .id(fromLocationAndName(from.location(), from.name()).slashEncode())
               .processors(ImmutableList.of(new Processor(from.numberOfCores(), 2)))
               .ram(from.memoryInMB())
-              .location(from.globallyAvailable() ? null : FluentIterable.from(locations.get())
+              .location(FluentIterable.from(locations.get())
                       .firstMatch(LocationPredicates.idEquals(from.location()))
                       .get());
 

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/VirtualMachineToNodeMetadata.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/functions/VirtualMachineToNodeMetadata.java
@@ -22,8 +22,6 @@ import static com.google.common.collect.Iterables.find;
 import static org.jclouds.azurecompute.arm.compute.AzureComputeServiceAdapter.GROUP_KEY;
 import static org.jclouds.azurecompute.arm.compute.domain.LocationAndName.fromLocationAndName;
 import static org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndName.fromResourceGroupAndName;
-import static org.jclouds.azurecompute.arm.compute.functions.VMImageToImage.encodeFieldsToUniqueId;
-import static org.jclouds.azurecompute.arm.compute.functions.VMImageToImage.encodeFieldsToUniqueIdCustom;
 import static org.jclouds.azurecompute.arm.domain.IdReference.extractResourceGroup;
 import static org.jclouds.compute.util.ComputeServiceUtils.addMetadataAndParseTagsFromCommaDelimitedValue;
 import static org.jclouds.location.predicates.LocationPredicates.idEquals;
@@ -185,10 +183,9 @@ public class VirtualMachineToNodeMetadata implements Function<VirtualMachine, No
 
    protected Optional<? extends Image> findImage(final StorageProfile storageProfile, String locatioName) {
       if (storageProfile.imageReference() != null) {
-         // FIXME check this condition
          String imageId = storageProfile.imageReference().customImageId() != null ?
-               encodeFieldsToUniqueIdCustom(false, locatioName, storageProfile.imageReference()) :
-               encodeFieldsToUniqueId(false, locatioName, storageProfile.imageReference());
+               storageProfile.imageReference().encodeFieldsToUniqueIdCustom(locatioName) :
+               storageProfile.imageReference().encodeFieldsToUniqueId(locatioName); 
          return imageCache.get(imageId);
       } else {
          logger.warn("could not find image for storage profile %s", storageProfile);

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/loaders/CreateSecurityGroupIfNeeded.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/loaders/CreateSecurityGroupIfNeeded.java
@@ -28,7 +28,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.jclouds.azurecompute.arm.AzureComputeApi;
-import org.jclouds.azurecompute.arm.compute.domain.RegionAndIdAndIngressRules;
+import org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndNameAndIngressRules;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityGroup;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityGroupProperties;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityRule;
@@ -36,32 +36,27 @@ import org.jclouds.azurecompute.arm.domain.NetworkSecurityRuleProperties;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityRuleProperties.Access;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityRuleProperties.Direction;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityRuleProperties.Protocol;
-import org.jclouds.azurecompute.arm.domain.ResourceGroup;
 import org.jclouds.compute.reference.ComputeServiceConstants;
 import org.jclouds.logging.Logger;
 
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 
 @Singleton
-public class CreateSecurityGroupIfNeeded extends CacheLoader<RegionAndIdAndIngressRules, String> {
+public class CreateSecurityGroupIfNeeded extends CacheLoader<ResourceGroupAndNameAndIngressRules, String> {
    @Resource
    @Named(ComputeServiceConstants.COMPUTE_LOGGER)
    protected Logger logger = Logger.NULL;
 
    private final AzureComputeApi api;
-   private final LoadingCache<String, ResourceGroup> resourceGroupMap;
 
    @Inject
-   CreateSecurityGroupIfNeeded(AzureComputeApi api, LoadingCache<String, ResourceGroup> resourceGroupMap) {
+   CreateSecurityGroupIfNeeded(AzureComputeApi api) {
       this.api = api;
-      this.resourceGroupMap = resourceGroupMap;
    }
 
    @Override
-   public String load(RegionAndIdAndIngressRules key) throws Exception {
-      ResourceGroup resourceGroup = resourceGroupMap.getUnchecked(key.region());
-      return createSecurityGroup(key.region(), resourceGroup.name(), key.id(), key.inboundPorts());
+   public String load(ResourceGroupAndNameAndIngressRules key) throws Exception {
+      return createSecurityGroup(key.location(), key.resourceGroup(), key.name(), key.inboundPorts());
    }
 
    private String createSecurityGroup(String location, String resourceGroup, String name, int[] inboundPorts) {

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/loaders/DefaultResourceGroup.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/loaders/DefaultResourceGroup.java
@@ -34,7 +34,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.collect.ImmutableMap;
 
 @Singleton
-public class ResourceGroupForLocation extends CacheLoader<String, ResourceGroup> {
+public class DefaultResourceGroup extends CacheLoader<String, ResourceGroup> {
    @Resource
    @Named(ComputeServiceConstants.COMPUTE_LOGGER)
    protected Logger logger = Logger.NULL;
@@ -43,7 +43,7 @@ public class ResourceGroupForLocation extends CacheLoader<String, ResourceGroup>
    private final LocationToResourceGroupName locationToResourceGroupName;
 
    @Inject
-   ResourceGroupForLocation(AzureComputeApi api, LocationToResourceGroupName locationToResourceGroupName) {
+   DefaultResourceGroup(AzureComputeApi api, LocationToResourceGroupName locationToResourceGroupName) {
       this.api = api.getResourceGroupApi();
       this.locationToResourceGroupName = locationToResourceGroupName;
    }
@@ -54,7 +54,7 @@ public class ResourceGroupForLocation extends CacheLoader<String, ResourceGroup>
       ResourceGroup resourceGroup = api.get(azureGroupName);
       if (resourceGroup == null) {
          logger.debug(">> creating resource group %s", azureGroupName);
-         final Map<String, String> tags = ImmutableMap.of("description", "jclouds managed VMs");
+         final Map<String, String> tags = ImmutableMap.of("description", "jclouds default resource group");
          resourceGroup = api.create(azureGroupName, locationId, tags);
       }
       return resourceGroup;

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/options/AzureTemplateOptions.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/options/AzureTemplateOptions.java
@@ -34,10 +34,10 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
 
    private String virtualNetworkName;
    private String subnetId;
-   private String blob;
    private AvailabilitySet availabilitySet;
    private String availabilitySetName;
    private List<DataDisk> dataDisks = ImmutableList.of();
+   private String resourceGroup;
 
    /**
     * Sets the virtual network name
@@ -52,14 +52,6 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
     */
    public  AzureTemplateOptions subnetId(String subnetId) {
       this.subnetId = subnetId;
-      return this;
-   }
-
-   /**
-    * Sets the blob name
-    */
-   public  AzureTemplateOptions blob(String blob) {
-      this.blob = blob;
       return this;
    }
    
@@ -80,6 +72,14 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
       this.availabilitySetName = availabilitySetName;
       return this;
    }
+   
+   /**
+    * The resource group where the new resources will be created.
+    */
+   public AzureTemplateOptions resourceGroup(String resourceGroup) {
+      this.resourceGroup = resourceGroup;
+      return this;
+   }
 
    public AzureTemplateOptions dataDisks(Iterable<DataDisk> dataDisks) {
       for (DataDisk dataDisk : checkNotNull(dataDisks, "dataDisks"))
@@ -94,12 +94,10 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
    
    public String getVirtualNetworkName() { return virtualNetworkName; }
    public String getSubnetId() { return subnetId; }
-   public String getBlob() { return blob; }
    public AvailabilitySet getAvailabilitySet() { return availabilitySet; }
    public String getAvailabilitySetName() { return availabilitySetName; }
-   public List<DataDisk> getDataDisks() {
-      return dataDisks;
-   }
+   public List<DataDisk> getDataDisks() { return dataDisks; }
+   public String getResourceGroup() { return resourceGroup; }
 
    @Override
    public AzureTemplateOptions clone() {
@@ -115,10 +113,10 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
          AzureTemplateOptions eTo = AzureTemplateOptions.class.cast(to);
          eTo.virtualNetworkName(virtualNetworkName);
          eTo.subnetId(subnetId);
-         eTo.blob(blob);
          eTo.availabilitySet(availabilitySet);
          eTo.availabilitySet(availabilitySetName);
          eTo.dataDisks(dataDisks);
+         eTo.resourceGroup(resourceGroup);
       }
    }
 
@@ -129,28 +127,19 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
       if (!super.equals(o)) return false;
 
       AzureTemplateOptions that = (AzureTemplateOptions) o;
-
-      if (virtualNetworkName != null ? !virtualNetworkName.equals(that.virtualNetworkName) : that.virtualNetworkName != null)
-         return false;
-      if (subnetId != null ? !subnetId.equals(that.subnetId) : that.subnetId != null) return false;
-      if (blob != null ? !blob.equals(that.blob) : that.blob != null) return false;
-      if (availabilitySet != null ? !availabilitySet.equals(that.availabilitySet) : that.availabilitySet != null)
-         return false;
-      if (availabilitySetName != null ? !availabilitySetName.equals(that.availabilitySetName) : that.availabilitySetName != null)
-         return false;
-      return dataDisks != null ? dataDisks.equals(that.dataDisks) : that.dataDisks == null;
+      
+      return Objects.equal(virtualNetworkName, that.virtualNetworkName) &&
+            Objects.equal(subnetId, that.subnetId) &&
+            Objects.equal(availabilitySet, that.availabilitySet) &&
+            Objects.equal(availabilitySetName, that.availabilitySetName) &&
+            Objects.equal(dataDisks, that.dataDisks) &&
+            Objects.equal(resourceGroup, that.resourceGroup);
    }
 
    @Override
    public int hashCode() {
-      int result = super.hashCode();
-      result = 31 * result + (virtualNetworkName != null ? virtualNetworkName.hashCode() : 0);
-      result = 31 * result + (subnetId != null ? subnetId.hashCode() : 0);
-      result = 31 * result + (blob != null ? blob.hashCode() : 0);
-      result = 31 * result + (availabilitySet != null ? availabilitySet.hashCode() : 0);
-      result = 31 * result + (availabilitySetName != null ? availabilitySetName.hashCode() : 0);
-      result = 31 * result + (dataDisks != null ? dataDisks.hashCode() : 0);
-      return result;
+      return Objects.hashCode(virtualNetworkName, subnetId, availabilitySet, availabilitySetName, dataDisks,
+            resourceGroup);
    }
 
    @Override
@@ -160,14 +149,14 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
          toString.add("virtualNetworkName", virtualNetworkName);
       if (subnetId != null)
          toString.add("subnetId", subnetId);
-      if (blob != null)
-         toString.add("blob", blob);
       if (availabilitySet != null)
          toString.add("availabilitySet", availabilitySet);
       if (availabilitySetName != null)
          toString.add("availabilitySetName", availabilitySetName);
       if (!dataDisks.isEmpty())
          toString.add("dataDisks", dataDisks);
+      if (resourceGroup != null)
+         toString.add("resourceGroup", resourceGroup);
       return toString;
    }
 
@@ -188,14 +177,6 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
          AzureTemplateOptions options = new AzureTemplateOptions();
          return options.subnetId(subnetId);
       }
-
-      /**
-       * @see AzureTemplateOptions#blob(String)
-       */
-      public static AzureTemplateOptions blob(String blob) {
-         AzureTemplateOptions options = new AzureTemplateOptions();
-         return options.blob(blob);
-      }
       
       /**
        * @see AzureTemplateOptions#availabilitySet(AvailabilitySet)
@@ -214,16 +195,27 @@ public class AzureTemplateOptions extends TemplateOptions implements Cloneable {
       }
 
       /**
-       * @see AzureTemplateOptions#dataDisks
+       * @see AzureTemplateOptions#dataDisks(DataDisk...)
        */
       public static AzureTemplateOptions dataDisks(DataDisk... dataDisks) {
          AzureTemplateOptions options = new AzureTemplateOptions();
          return options.dataDisks(dataDisks);
       }
 
+      /**
+       * @see AzureTemplateOptions#dataDisks(Iterable)
+       */
       public static AzureTemplateOptions dataDisks(Iterable<DataDisk> dataDisks) {
          AzureTemplateOptions options = new AzureTemplateOptions();
          return options.dataDisks(dataDisks);
+      }
+      
+      /**
+       * @see AzureTemplateOptions#resourceGroup(String)
+       */
+      public static AzureTemplateOptions resourceGroup(String resourceGroup) {
+         AzureTemplateOptions options = new AzureTemplateOptions();
+         return options.resourceGroup(resourceGroup);
       }
    }
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/strategy/CreateResourcesThenCreateNodes.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/strategy/CreateResourcesThenCreateNodes.java
@@ -16,6 +16,12 @@
  */
 package org.jclouds.azurecompute.arm.compute.strategy;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.DEFAULT_SUBNET_ADDRESS_PREFIX;
+import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.DEFAULT_VNET_ADDRESS_SPACE_PREFIX;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -27,12 +33,12 @@ import javax.inject.Singleton;
 
 import org.jclouds.Constants;
 import org.jclouds.azurecompute.arm.AzureComputeApi;
-import org.jclouds.azurecompute.arm.compute.domain.RegionAndIdAndIngressRules;
+import org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndName;
+import org.jclouds.azurecompute.arm.compute.domain.ResourceGroupAndNameAndIngressRules;
 import org.jclouds.azurecompute.arm.compute.functions.TemplateToAvailabilitySet;
 import org.jclouds.azurecompute.arm.compute.options.AzureTemplateOptions;
 import org.jclouds.azurecompute.arm.domain.AvailabilitySet;
 import org.jclouds.azurecompute.arm.domain.NetworkSecurityGroup;
-import org.jclouds.azurecompute.arm.domain.RegionAndId;
 import org.jclouds.azurecompute.arm.domain.ResourceGroup;
 import org.jclouds.azurecompute.arm.domain.Subnet;
 import org.jclouds.azurecompute.arm.domain.VirtualNetwork;
@@ -42,7 +48,6 @@ import org.jclouds.compute.config.CustomizationResponse;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.functions.GroupNamingConvention;
-import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.compute.reference.ComputeServiceConstants;
 import org.jclouds.compute.strategy.CreateNodeWithGroupEncodedIntoName;
 import org.jclouds.compute.strategy.CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap;
@@ -53,32 +58,26 @@ import org.jclouds.logging.Logger;
 
 import com.google.common.base.Optional;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Iterables.getOnlyElement;
-import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.DEFAULT_SUBNET_ADDRESS_PREFIX;
-import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.DEFAULT_VNET_ADDRESS_SPACE_PREFIX;
-
 @Singleton
-public class CreateResourceGroupThenCreateNodes extends CreateNodesWithGroupEncodedIntoNameThenAddToSet {
+public class CreateResourcesThenCreateNodes extends CreateNodesWithGroupEncodedIntoNameThenAddToSet {
 
    @Resource
    @Named(ComputeServiceConstants.COMPUTE_LOGGER)
    protected Logger logger = Logger.NULL;
 
    private final AzureComputeApi api;
-   private final LoadingCache<RegionAndIdAndIngressRules, String> securityGroupMap;
-   private final LoadingCache<String, ResourceGroup> resourceGroupMap;
+   private final LoadingCache<ResourceGroupAndNameAndIngressRules, String> securityGroupMap;
    private final String defaultVnetAddressPrefix;
    private final String defaultSubnetAddressPrefix;
    private final TemplateToAvailabilitySet templateToAvailabilitySet;
 
    @Inject
-   protected CreateResourceGroupThenCreateNodes(
+   protected CreateResourcesThenCreateNodes(
          CreateNodeWithGroupEncodedIntoName addNodeWithGroupStrategy,
          ListNodesStrategy listNodesStrategy,
          GroupNamingConvention.Factory namingConvention,
@@ -86,15 +85,13 @@ public class CreateResourceGroupThenCreateNodes extends CreateNodesWithGroupEnco
          CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.Factory customizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapFactory,
          AzureComputeApi api, @Named(DEFAULT_VNET_ADDRESS_SPACE_PREFIX) String defaultVnetAddressPrefix,
          @Named(DEFAULT_SUBNET_ADDRESS_PREFIX) String defaultSubnetAddressPrefix,
-         LoadingCache<RegionAndIdAndIngressRules, String> securityGroupMap,
-         LoadingCache<String, ResourceGroup> resourceGroupMap, 
+         LoadingCache<ResourceGroupAndNameAndIngressRules, String> securityGroupMap,
          TemplateToAvailabilitySet templateToAvailabilitySet) {
       super(addNodeWithGroupStrategy, listNodesStrategy, namingConvention, userExecutor,
             customizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapFactory);
       this.api = checkNotNull(api, "api cannot be null");
       checkNotNull(userExecutor, "userExecutor cannot be null");
       this.securityGroupMap = securityGroupMap;
-      this.resourceGroupMap = resourceGroupMap;
       this.defaultVnetAddressPrefix = defaultVnetAddressPrefix;
       this.defaultSubnetAddressPrefix = defaultSubnetAddressPrefix;
       this.templateToAvailabilitySet = templateToAvailabilitySet;
@@ -117,24 +114,22 @@ public class CreateResourceGroupThenCreateNodes extends CreateNodesWithGroupEnco
 
       // This sill create the resource group if it does not exist
       String location = template.getLocation().getId();
-      ResourceGroup resourceGroup = resourceGroupMap.getUnchecked(location);
-      String azureGroupName = resourceGroup.name();
 
-      getOrCreateVirtualNetworkWithSubnet(location, options, azureGroupName);
-      configureSecurityGroupForOptions(group, azureGroupName, template.getLocation(), options);
+      createResourceGroupIfNeeded(group, location, options);
+      getOrCreateVirtualNetworkWithSubnet(location, options);
+      configureSecurityGroupForOptions(group, template.getLocation(), options);
       configureAvailabilitySetForTemplate(template);
 
       return super.execute(group, count, template, goodNodes, badNodes, customizationResponses);
    }
 
-   protected synchronized void getOrCreateVirtualNetworkWithSubnet(final String location, AzureTemplateOptions options,
-         final String azureGroupName) {
+   protected synchronized void getOrCreateVirtualNetworkWithSubnet(final String location, AzureTemplateOptions options) {
       String virtualNetworkName = Optional.fromNullable(options.getVirtualNetworkName()).or(
-            azureGroupName + "virtualnetwork");
-      String subnetName = azureGroupName + "subnet";
+            options.getResourceGroup() + "virtualnetwork");
+      String subnetName = options.getResourceGroup() + "subnet";
 
       // Subnets belong to a virtual network so that needs to be created first
-      VirtualNetworkApi vnApi = api.getVirtualNetworkApi(azureGroupName);
+      VirtualNetworkApi vnApi = api.getVirtualNetworkApi(options.getResourceGroup());
       VirtualNetwork vn = vnApi.get(virtualNetworkName);
 
       if (vn == null) {
@@ -148,7 +143,7 @@ public class CreateResourceGroupThenCreateNodes extends CreateNodesWithGroupEnco
          vn = vnApi.createOrUpdate(virtualNetworkName, location, virtualNetworkProperties);
       }
 
-      SubnetApi subnetApi = api.getSubnetApi(azureGroupName, virtualNetworkName);
+      SubnetApi subnetApi = api.getSubnetApi(options.getResourceGroup(), virtualNetworkName);
       Subnet subnet = subnetApi.get(subnetName);
 
       options.virtualNetworkName(virtualNetworkName);
@@ -160,23 +155,21 @@ public class CreateResourceGroupThenCreateNodes extends CreateNodesWithGroupEnco
             && !template.getOptions().hasLoginPrivateKeyOption();
    }
 
-   private void configureSecurityGroupForOptions(String group, String resourceGroup, Location location,
-         TemplateOptions options) {
+   private void configureSecurityGroupForOptions(String group, Location location, AzureTemplateOptions options) {
 
       checkArgument(options.getGroups().size() <= 1,
             "Only one security group can be configured for each network interface");
 
       if (!options.getGroups().isEmpty()) {
-         String groupName = getOnlyElement(options.getGroups());
-         String groupNameWithourRegion = groupName.indexOf('/') == -1 ? groupName : RegionAndId.fromSlashEncoded(
-               groupName).id();
-         NetworkSecurityGroup securityGroup = api.getNetworkSecurityGroupApi(resourceGroup).get(groupNameWithourRegion);
-         checkArgument(securityGroup != null, "Security group %s was not found", groupName);
+         ResourceGroupAndName securityGroupId = ResourceGroupAndName.fromSlashEncoded(getOnlyElement(options.getGroups()));
+         NetworkSecurityGroup securityGroup = api.getNetworkSecurityGroupApi(securityGroupId.resourceGroup()).get(
+               securityGroupId.name());
+         checkArgument(securityGroup != null, "Security group %s was not found", securityGroupId.slashEncode());
          options.securityGroups(securityGroup.id());
       } else if (options.getInboundPorts().length > 0) {
          String name = namingConvention.create().sharedNameForGroup(group);
-         RegionAndIdAndIngressRules regionAndIdAndIngressRules = RegionAndIdAndIngressRules.create(location.getId(),
-               name, options.getInboundPorts());
+         ResourceGroupAndNameAndIngressRules regionAndIdAndIngressRules = ResourceGroupAndNameAndIngressRules.create(
+               options.getResourceGroup(), location.getId(), name, options.getInboundPorts());
          // this will create if not yet exists.
          String securityGroupId = securityGroupMap.getUnchecked(regionAndIdAndIngressRules);
          options.securityGroups(securityGroupId);
@@ -188,6 +181,19 @@ public class CreateResourceGroupThenCreateNodes extends CreateNodesWithGroupEnco
       if (availabilitySet != null) {
          logger.debug(">> configuring nodes in availability set [%s]", availabilitySet.name());
          template.getOptions().as(AzureTemplateOptions.class).availabilitySet(availabilitySet);
+      }
+   }
+   
+   private void createResourceGroupIfNeeded(String group, String location, AzureTemplateOptions options) {
+      if (options.getResourceGroup() == null) {
+         options.resourceGroup(group);
+      }
+      logger.debug(">> using resource group [%s]", options.getResourceGroup());
+      ResourceGroup rg = api.getResourceGroupApi().get(options.getResourceGroup());
+      if (rg == null) {
+         logger.debug(">> resource group [%s] does not exist. Creating!", options.getResourceGroup());
+         api.getResourceGroupApi().create(options.getResourceGroup(), location,
+               ImmutableMap.of("description", "jclouds default resource group"));
       }
    }
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/IdReference.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/IdReference.java
@@ -16,19 +16,56 @@
  */
 package org.jclouds.azurecompute.arm.domain;
 
-import com.google.auto.value.AutoValue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
 
 // Simple helper class to serialize / deserialize id reference.
 
 @AutoValue
 public abstract class IdReference {
+   
+   private static final Pattern RESOURCE_GROUP_PATTERN = Pattern.compile("^.*/resourceGroups/([^/]+)(/.*)?$");
+   
    @Nullable
    public abstract String id();
+   
+   @Nullable
+   public String resourceGroup() {
+      return extractResourceGroup(id());
+   }
+   
+   @Nullable
+   public String name() {
+      return extractName(id());
+   }
 
    @SerializedNames({"id"})
    public static IdReference create(final String id) {
       return new AutoValue_IdReference(id);
+   }
+   
+   /**
+    * Extracts the name from the given URI.
+    */
+   public static String extractName(String uri) {
+      if (uri == null)
+         return null;
+      String noSlashAtEnd = uri.replaceAll("/+$", "");
+      return noSlashAtEnd.substring(noSlashAtEnd.lastIndexOf('/') + 1);
+   }
+   
+   /**
+    * Extracts the resource group name from the given URI.
+    */
+   public static String extractResourceGroup(String uri) {
+      if (uri == null)
+         return null;
+      Matcher m = RESOURCE_GROUP_PATTERN.matcher(uri);
+      return m.matches() ? m.group(1) : null;
    }
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/ImageReference.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/ImageReference.java
@@ -16,6 +16,9 @@
  */
 package org.jclouds.azurecompute.arm.domain;
 
+import static org.jclouds.azurecompute.arm.domain.IdReference.extractName;
+import static org.jclouds.azurecompute.arm.domain.IdReference.extractResourceGroup;
+
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
@@ -89,5 +92,15 @@ public abstract class ImageReference {
       public abstract Builder version(String version);
 
       public abstract ImageReference build();
+   }
+   
+   public String encodeFieldsToUniqueId(String location) {
+      return VMImage.azureImage().location(location).publisher(publisher()).offer(offer()).sku(sku()).build()
+            .encodeFieldsToUniqueId();
+   }
+
+   public String encodeFieldsToUniqueIdCustom(String location) {
+      return VMImage.customImage().resourceGroup(extractResourceGroup(customImageId())).location(location)
+            .name(extractName(customImageId())).build().encodeFieldsToUniqueIdCustom();
    }
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/LoadBalancer.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/LoadBalancer.java
@@ -26,25 +26,42 @@ import com.google.common.collect.ImmutableMap;
 
 @AutoValue
 public abstract class LoadBalancer {
-   @Nullable
-   public abstract String name();
+   
+   @Nullable public abstract String id();
+   @Nullable public abstract String name();
+   @Nullable public abstract String location();
+   @Nullable public abstract String etag();
+   @Nullable public abstract Map<String, String> tags();
+   @Nullable public abstract LoadBalancerProperties properties();
 
-   @Nullable
-   public abstract String location();
+   @SerializedNames({ "id", "name", "location", "etag", "tags", "properties", })
+   public static LoadBalancer create(String id, final String name, final String location, final String etag,
+         final Map<String, String> tags, final LoadBalancerProperties properties) {
+      return builder().id(id).name(name).location(location).etag(etag).tags(tags).properties(properties).build();
+   }
+   
+   public abstract Builder toBuilder();
 
-   @Nullable
-   public abstract Map<String, String> tags();
+   public static Builder builder() {
+      return new AutoValue_LoadBalancer.Builder();
+   }
+   
+   @AutoValue.Builder
+   public abstract static class Builder {
+      public abstract Builder id(String id);
+      public abstract Builder name(String name);
+      public abstract Builder location(String location);
+      public abstract Builder etag(String etag);
+      public abstract Builder tags(Map<String, String> tags);
+      public abstract Builder properties(LoadBalancerProperties properties);
+      
+      abstract Map<String, String> tags();
 
-   @Nullable
-   public abstract LoadBalancerProperties properties();
-
-   @Nullable
-   public abstract String etag();
-
-   @SerializedNames({ "name", "location", "tags", "properties", "etag" })
-   public static LoadBalancer create(final String name, final String location, final Map<String, String> tags,
-         final LoadBalancerProperties properties, final String etag) {
-      return new AutoValue_LoadBalancer(name, location, tags == null ? null : ImmutableMap.copyOf(tags), properties,
-            etag);
+      abstract LoadBalancer autoBuild();
+      
+      public LoadBalancer build() {
+         tags(tags() != null ? ImmutableMap.copyOf(tags()) : null);
+         return autoBuild();
+      }
    }
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/VMHardware.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/VMHardware.java
@@ -62,14 +62,9 @@ public abstract class VMHardware {
     */
    public abstract String location();
 
-   /**
-    * Specifies if this HW is globally available
-    */
-   public abstract boolean globallyAvailable();
+   @SerializedNames({ "name", "numberOfCores", "osDiskSizeInMB", "resourceDiskSizeInMB", "memoryInMB", "maxDataDiskCount", "location"})
+   public static VMHardware create(String name, Integer numberOfCores, Integer osDiskSizeInMB, Integer resourceDiskSizeInMB, Integer memoryInMB, Integer maxDataDiskCount, String location) {
 
-   @SerializedNames({ "name", "numberOfCores", "osDiskSizeInMB", "resourceDiskSizeInMB", "memoryInMB", "maxDataDiskCount", "location", "globallyAvailable"})
-   public static VMHardware create(String name, Integer numberOfCores, Integer osDiskSizeInMB, Integer resourceDiskSizeInMB, Integer memoryInMB, Integer maxDataDiskCount, String location, boolean globallyAvailable) {
-
-      return new AutoValue_VMHardware(name, numberOfCores, osDiskSizeInMB, resourceDiskSizeInMB, memoryInMB, maxDataDiskCount, location, globallyAvailable);
+      return new AutoValue_VMHardware(name, numberOfCores, osDiskSizeInMB, resourceDiskSizeInMB, memoryInMB, maxDataDiskCount, location);
    }
 }

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/VMImage.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/VMImage.java
@@ -98,6 +98,13 @@ public abstract class VMImage {
     */
    @Nullable
    public abstract String customImageId();
+   
+   /**
+    * The resource group for the image in case of custom images.
+    * @return
+    */
+   @Nullable
+   public abstract String resourceGroup();
 
    /**
     * Extended version properties.
@@ -127,6 +134,7 @@ public abstract class VMImage {
    public abstract static class Builder {
 
       public abstract Builder customImageId(String id);
+      public abstract Builder resourceGroup(String resourceGroup);
       public abstract Builder publisher(String published);
       public abstract Builder offer(String offer);
       public abstract Builder sku(String sku);

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/features/JobApi.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/features/JobApi.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.jclouds.azurecompute.arm.features;
+
 import java.io.Closeable;
 import java.net.URI;
 import java.util.List;
@@ -37,7 +38,6 @@ import org.jclouds.rest.annotations.SelectJson;
 /**
  * The Azure Resource Manager API checks for job status and progress.
  */
-
 @RequestFilters(OAuthFilter.class)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface JobApi extends Closeable {

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/util/VMImages.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/util/VMImages.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class VMImages {
 
    public static boolean isCustom(String imageId) {
-      return checkNotNull(imageId, "id").split("/").length == 2;
+      return checkNotNull(imageId, "id").split("/").length == 3;
    }
   
 }

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/compute/AzureTemplateBuilderLiveTest.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/compute/AzureTemplateBuilderLiveTest.java
@@ -56,7 +56,7 @@ public class AzureTemplateBuilderLiveTest extends BaseTemplateBuilderLiveTest {
    @Override
    protected Properties setupProperties() {
       Properties properties = super.setupProperties();
-      AzureLiveTestUtils.defaultProperties(properties, getClass().getSimpleName().toLowerCase());
+      AzureLiveTestUtils.defaultProperties(properties);
       setIfTestSystemPropertyPresent(properties, "oauth.endpoint");
       return properties;
    }

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/domain/IdReferenceTest.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/domain/IdReferenceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azurecompute.arm.domain;
+
+import static org.jclouds.azurecompute.arm.domain.IdReference.extractName;
+import static org.jclouds.azurecompute.arm.domain.IdReference.extractResourceGroup;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class IdReferenceTest {
+
+   @Test
+   public void testExtractResourceGroup() {
+      assertEquals(extractResourceGroup(null), null);
+      assertEquals(extractResourceGroup(""), null);
+      assertEquals(
+            extractResourceGroup("/subscriptions/subscription/resourceGroups/jclouds-northeurope/providers/Microsoft.Compute/virtualMachines/resources-8c5"),
+            "jclouds-northeurope");
+      assertEquals(extractResourceGroup("/subscriptions/subscription/resourceGroups/jclouds-west"), "jclouds-west");
+      assertEquals(extractResourceGroup("/resourceGroups/jclouds-west2"), "jclouds-west2");
+      assertEquals(
+            extractResourceGroup("/resourceGroups/jclouds-northeurope2/providers/Microsoft.Compute/virtualMachines/resources-8c5"),
+            "jclouds-northeurope2");
+      assertEquals(extractResourceGroup("resourceGroups/jclouds-west2"), null);
+      assertEquals(
+            extractResourceGroup("resourceGroups/jclouds-northeurope2/providers/Microsoft.Compute/virtualMachines/resources-8c5"),
+            null);
+      assertEquals(
+            extractResourceGroup("/subscriptions/subscription/providers/Microsoft.Compute/virtualMachines/resources-8c5"),
+            null);
+      assertEquals(
+            extractResourceGroup("/subscriptions/subscription/resourceGroups//jclouds-northeurope/providers/Microsoft.Compute/virtualMachines/resources-8c5"),
+            null);
+   }
+
+   @Test
+   public void testExtractName() {
+      assertEquals(extractName(null), null);
+      assertEquals(extractName(""), "");
+      assertEquals(extractName("foo"), "foo");
+      assertEquals(extractName("/foo/bar"), "bar");
+      assertEquals(extractName("/foo/bar/"), "bar");
+      assertEquals(extractName("/foo/bar////"), "bar");
+      assertEquals(extractName("/foo///bar////"), "bar");
+      assertEquals(extractName("////bar"), "bar");
+   }
+}

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/LoadBalancerApiLiveTest.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/LoadBalancerApiLiveTest.java
@@ -326,9 +326,13 @@ public class LoadBalancerApiLiveTest extends BaseComputeServiceContextLiveTest {
             .builder().build();
       FrontendIPConfigurations frontendIPConfigurations = FrontendIPConfigurations.create("ipConfigs", null,
             frontendIPConfigurationsProperties, null);
-      return LoadBalancer.create(lbName, locationName, null,
-            LoadBalancerProperties.builder().frontendIPConfigurations(ImmutableList.of(frontendIPConfigurations))
-                  .build(), null);
+      return LoadBalancer
+            .builder()
+            .name(lbName)
+            .location(locationName)
+            .properties(
+                  LoadBalancerProperties.builder().frontendIPConfigurations(ImmutableList.of(frontendIPConfigurations))
+                        .build()).build();
    }
 
    private void assertResourceDeleted(final URI uri) {

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/LoadBalancerApiMockTest.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/LoadBalancerApiMockTest.java
@@ -149,7 +149,12 @@ public class LoadBalancerApiMockTest extends BaseAzureComputeApiMockTest {
             .builder().build();
       FrontendIPConfigurations frontendIPConfigurations = FrontendIPConfigurations.create("ipConfigs", null,
             frontendIPConfigurationsProperties, null);
-      return LoadBalancer.create(lbName, "westus", null, LoadBalancerProperties.builder()
-            .frontendIPConfigurations(ImmutableList.of(frontendIPConfigurations)).build(), null);
+      return LoadBalancer
+            .builder()
+            .name(lbName)
+            .location("westus")
+            .properties(
+                  LoadBalancerProperties.builder().frontendIPConfigurations(ImmutableList.of(frontendIPConfigurations))
+                        .build()).build();
    }
 }

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/internal/AzureLiveTestUtils.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/internal/AzureLiveTestUtils.java
@@ -16,11 +16,7 @@
  */
 package org.jclouds.azurecompute.arm.internal;
 
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
 import static org.jclouds.azurecompute.arm.config.AzureComputeProperties.IMAGE_PUBLISHERS;
-import static org.jclouds.compute.config.ComputeServiceProperties.RESOURCENAME_PREFIX;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_RUNNING;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_SUSPENDED;
 import static org.jclouds.compute.config.ComputeServiceProperties.TIMEOUT_NODE_TERMINATED;
@@ -30,14 +26,16 @@ import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
 import static org.jclouds.oauth.v2.config.CredentialType.CLIENT_CREDENTIALS_SECRET;
 import static org.jclouds.oauth.v2.config.OAuthProperties.CREDENTIAL_TYPE;
 
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 public class AzureLiveTestUtils {
 
-   public static Properties defaultProperties(Properties properties, String resourceNamePrefix) {
+   public static Properties defaultProperties(Properties properties) {
       properties = properties == null ? new Properties() : properties;
       properties.put(CREDENTIAL_TYPE, CLIENT_CREDENTIALS_SECRET.toString());
       properties.put(PROPERTY_REGIONS, "westeurope");
       properties.put(IMAGE_PUBLISHERS, "Canonical");
-      properties.put(RESOURCENAME_PREFIX, resourceNamePrefix);
 
       String defaultTimeout = String.valueOf(TimeUnit.MILLISECONDS.convert(60, TimeUnit.MINUTES));
       properties.setProperty(TIMEOUT_SCRIPT_COMPLETE, defaultTimeout);

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/internal/BaseAzureComputeApiLiveTest.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/internal/BaseAzureComputeApiLiveTest.java
@@ -97,7 +97,7 @@ public class BaseAzureComputeApiLiveTest extends BaseApiLiveTest<AzureComputeApi
    @Override protected Properties setupProperties() {
       Properties properties = super.setupProperties();
       // for oauth
-      AzureLiveTestUtils.defaultProperties(properties, getClass().getSimpleName().toLowerCase());
+      AzureLiveTestUtils.defaultProperties(properties);
       checkNotNull(setIfTestSystemPropertyPresent(properties, "oauth.endpoint"), "test.oauth.endpoint");
       return properties;
    }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCLOUDS-1273

The compute service live tests pass (there is one transient failure unrelated to this change):

```bash
Failed tests: 
  AzureComputeServiceLiveTest>BaseComputeServiceLiveTest.testOptionToNotBlock:870 duration(37) longer than expected(30) seconds! 

Tests run: 27, Failures: 1, Errors: 0, Skipped: 0
Total time: 01:10 h (Wall Clock)
```

I still have some manual tests pending to make sure everything works as expected, but I'm submitting this for early feedback. The changes in this PR are:

* The ID returned for the nodes, security groups, etc, has been changed from `location/name` to `resourceGroup/name` to better reflect the path they have in the ARM API.
* Added helper methods to the `IdReference` class to extract the resource group and name from the object's URI. This helps hen getting resources by id and to build the APIs pointing to the right resource group (not the default one for the location).
* Methods that list resources (listNodes, listSecurityGroups, etc) have been changed to consider all existing resource groups.
* All transformation functions take into account the resource group of the current object instead of the default one (this was the root cause of the linked issue).
* The `resourceGroupMap` has been renamed to `defaultResourceGroup` and its usage has been removed from all classes. The only class using it is the SecurityGroupExtension, since there is no mean to specify the resource group where the security group should be created. They are created in the default one when using the extension.
* A `resourceGroup` method has been added to the `AzureTemplateOptions` to let users configure the resource group where all stuff will be created when creating nodes.

@andreaturli @danielestevez feedback and tests welcome!