### PR TITLE
Fix SGE.removeSecurityGroup for when the SG doesn't exist

### DIFF
--- a/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
@@ -190,7 +190,15 @@ public class AzureComputeSecurityGroupExtension implements SecurityGroupExtensio
       final ResourceGroupAndName resourceGroupAndName = ResourceGroupAndName.fromSlashEncoded(id);
       URI uri = api.getNetworkSecurityGroupApi(resourceGroupAndName.resourceGroup())
             .delete(resourceGroupAndName.name());
-      return resourceDeleted.apply(uri);
+
+      // https://docs.microsoft.com/en-us/rest/api/network/virtualnetwork/delete-a-network-security-group
+      if (uri != null) {
+         // 202-Accepted if resource exists and the request is accepted.
+         return resourceDeleted.apply(uri);
+      } else {
+         // 204-No Content if resource does not exist.
+         return false;
+      }
    }
 
    @Override


### PR DESCRIPTION
@nacx reported the problem in the `Re: [DISCUSS] Release Apache jclouds 2.0.2 RC1` email thread. Failure:

```
testSecurityGroupCacheInvalidatedWhenDeletedExternally(org.jclouds.azurecompute.arm.compute.extensions.AzureComputeSecurityGroupExtensionLiveTest)
Time elapsed: 2.928 sec  <<< FAILURE!
java.lang.NullPointerException: uri cannot be null
at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:229)
at org.jclouds.azurecompute.arm.compute.config.AzureComputeServiceContextModule$ActionDonePredicate.apply(AzureComputeServiceContextModule.java:230)
at org.jclouds.azurecompute.arm.compute.config.AzureComputeServiceContextModule$ActionDonePredicate.apply(AzureComputeServiceContextModule.java:219)
at org.jclouds.util.Predicates2$RetryablePredicate.apply(Predicates2.java:117)
at org.jclouds.azurecompute.arm.compute.extensions.AzureComputeSecurityGroupExtension.removeSecurityGroup(AzureComputeSecurityGroupExtension.java:193)
at org.jclouds.compute.extensions.internal.BaseSecurityGroupExtensionLiveTest.testSecurityGroupCacheInvalidatedWhenDeletedExternally(BaseSecurityGroupExtensionLiveTest.java:417)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:606)
at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
at org.testng.internal.Invoker.invokeMethod(Invoker.java:696)
at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:882)
at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1189)
at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:124)
at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
at org.testng.TestRunner.privateRun(TestRunner.java:767)
at org.testng.TestRunner.run(TestRunner.java:617)
at org.testng.SuiteRunner.runTest(SuiteRunner.java:348)
at org.testng.SuiteRunner.access$000(SuiteRunner.java:38)
at org.testng.SuiteRunner$SuiteWorker.run(SuiteRunner.java:382)
at org.testng.internal.thread.ThreadUtil$2.call(ThreadUtil.java:64)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)
```