### PR TITLE
Vagrant support for multiple providers

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -109,6 +109,31 @@ make virtualbox/eval-win2012r2-standard
 vagrant box add boxcutter/eval-win2012r2-standard ./box/virtualbox/eval-win2012r2-standard-nocm-1.0.4.box
 ```
 
+Vagrant providers
+-----------
+
+jclouds supports the virtualbox an libvirt providers out of the box. To use additional providers users need to let
+jclouds know how to configure them. For example how to turn configuration like number of cpus or amount of memory to
+the provider specific configuration. Additional configuration might be needed as well. This is not required, but not
+providing it will lead to VMs which ignore configuration passed in from jclouds.
+
+To let jclouds configure additional providers create a Ruby file in ~/.jclouds/vagrant/providers. In the file
+register a block to do the configuration, by calling into `CustomProviders.register`. The block will be passed
+two arguments - `config` which is the Vagrant provided machine config and `machine_config` which is the configuration
+coming from jclouds. Here's an example file for `libvirt`.
+
+```
+CustomProviders.register do |config, machine_config|
+  config.vm.provider "libvirt" do |v|
+    v.memory = machine_config["memory"] if machine_config.key?("memory")
+    v.cpus = machine_config["cpus"] if machine_config.key?("cpus")
+  end
+end
+```
+
+jclouds selects the provider to use based on the selected box. Each box lists the provider it's been created for.
+The current implementation supports just a single provider per box name.
+
 Cleaning up
 -----------
 

--- a/vagrant/pom.xml
+++ b/vagrant/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>name.neykov</groupId>
       <artifactId>vagrant-java-bindings</artifactId>
-      <version>0.1.1</version>
+      <version>0.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>

--- a/vagrant/src/main/java/org/jclouds/vagrant/api/VagrantApiFacade.java
+++ b/vagrant/src/main/java/org/jclouds/vagrant/api/VagrantApiFacade.java
@@ -30,7 +30,7 @@ public interface VagrantApiFacade {
     * 
     * @return the raw output of the configured provisioners
     */
-   String up(String machineName);
+   String up(String machineName, String provider);
    void halt(String machineName);
    void destroy(String machineName);
    LoginCredentials sshConfig(String machineName);

--- a/vagrant/src/main/java/org/jclouds/vagrant/compute/VagrantComputeServiceAdapter.java
+++ b/vagrant/src/main/java/org/jclouds/vagrant/compute/VagrantComputeServiceAdapter.java
@@ -110,9 +110,10 @@ public class VagrantComputeServiceAdapter implements ComputeServiceAdapter<Vagra
    }
 
    private NodeAndInitialCredentials<VagrantNode> startMachine(File path, String group, String name, Image image, Hardware hardware) {
+      String provider = image.getUserMetadata().get(VagrantConstants.USER_META_PROVIDER);
 
       VagrantApiFacade vagrant = cliFactory.create(path);
-      String rawOutput = vagrant.up(name);
+      String rawOutput = vagrant.up(name, provider);
       String output = normalizeOutput(name, rawOutput);
 
       OsFamily osFamily = image.getOperatingSystem().getFamily();
@@ -308,9 +309,10 @@ public class VagrantComputeServiceAdapter implements ComputeServiceAdapter<Vagra
       halt(id);
 
       VagrantNode node = nodeRegistry.get(id);
+      String provider = node.image().getUserMetadata().get(VagrantConstants.USER_META_PROVIDER);
       String name = node.name();
       VagrantApiFacade vagrant = getMachine(node);
-      vagrant.up(name);
+      vagrant.up(name, provider);
       node.setMachineState(Status.RUNNING);
    }
 
@@ -331,9 +333,10 @@ public class VagrantComputeServiceAdapter implements ComputeServiceAdapter<Vagra
    @Override
    public void resumeNode(String id) {
       VagrantNode node = nodeRegistry.get(id);
+      String provider = node.image().getUserMetadata().get(VagrantConstants.USER_META_PROVIDER);
       String name = node.name();
       VagrantApiFacade vagrant = getMachine(node);
-      vagrant.up(name);
+      vagrant.up(name, provider);
       node.setMachineState(Status.RUNNING);
    }
 

--- a/vagrant/src/main/java/org/jclouds/vagrant/compute/VagrantComputeServiceAdapter.java
+++ b/vagrant/src/main/java/org/jclouds/vagrant/compute/VagrantComputeServiceAdapter.java
@@ -165,8 +165,6 @@ public class VagrantComputeServiceAdapter implements ComputeServiceAdapter<Vagra
       Collection<String> ips = new ArrayList<String>();
       while (m.find()) {
          String network = m.group(1);
-         // TODO figure out a more generic approach to ignore unreachable networkds (this one is the NAT'd address).
-         if (network.startsWith("10.")) continue;
          ips.add(network);
       }
       return ips;

--- a/vagrant/src/main/java/org/jclouds/vagrant/internal/BoxConfig.java
+++ b/vagrant/src/main/java/org/jclouds/vagrant/internal/BoxConfig.java
@@ -37,10 +37,6 @@ public class BoxConfig {
          return new BoxConfig(getVagrantHome(), image.getName(), image.getVersion(), provider);
       }
 
-      public BoxConfig newInstance(File vagrantHome, Image image) {
-         return this.newInstance(getVagrantHome(), image);
-      }
-
       public BoxConfig newInstance(Box box) {
          return this.newInstance(getVagrantHome(), box);
       }

--- a/vagrant/src/main/java/org/jclouds/vagrant/internal/VagrantCliFacade.java
+++ b/vagrant/src/main/java/org/jclouds/vagrant/internal/VagrantCliFacade.java
@@ -54,9 +54,9 @@ public class VagrantCliFacade implements VagrantApiFacade, VagrantBoxApiFacade<B
    }
 
    @Override
-   public String up(String machineName) {
+   public String up(String machineName, String provider) {
       outputRecorder.record();
-      vagrant.up(machineName);
+      vagrant.up(machineName, provider);
       return outputRecorder.stopRecording();
    }
 

--- a/vagrant/src/main/resources/Vagrantfile
+++ b/vagrant/src/main/resources/Vagrantfile
@@ -18,6 +18,26 @@ require 'yaml'
 # Because of linked_clone. 1.9+ recommended for Ubuntu Xenial
 Vagrant.require_version ">= 1.8"
 
+module CustomProviders
+  @@providers = []
+  def register(&fn)
+    @@providers << fn
+  end
+  def configure(config, machine_config)
+    @@providers.each do |provider|
+      provider.call(config, machine_config)
+    end
+  end
+
+  module_function :register
+  module_function :configure
+end
+
+
+Dir[Dir.home() + '/.jclouds/vagrant/providers/*.rb'].each do |file|
+  require File.dirname(file) + "/" + File.basename(file, '.rb')
+end
+
 Vagrant.configure(2) do |config|
   Dir.glob('machines/*.yaml') do |machine_file|
     machine_config = YAML.load_file(machine_file)
@@ -69,12 +89,18 @@ Vagrant.configure(2) do |config|
         v.memory = machine_config["memory"] if machine_config.key?("memory")
         v.cpus = machine_config["cpus"] if machine_config.key?("cpus")
         v.linked_clone = true
-        # Windows needs additional drivers for virtio
+        # Windows needs additional drivers for virtio and the default one is dreadfully slow on linux
         if !isWindows
           v.customize ["modifyvm", :id, "--nictype1", "virtio"]
           v.customize ["modifyvm", :id, "--nictype2", "virtio"]
         end
       end
+      config.vm.provider "libvirt" do |v|
+        v.memory = machine_config["memory"] if machine_config.key?("memory")
+        v.cpus = machine_config["cpus"] if machine_config.key?("cpus")
+      end
+
+      CustomProviders.configure(config, machine_config)
     end
   end
 end

--- a/vagrant/src/test/resources/logback-test.xml
+++ b/vagrant/src/test/resources/logback-test.xml
@@ -23,9 +23,16 @@
             <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
         </encoder>
     </appender>
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
 
     <root level="INFO">
         <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
     </root>
 
     <logger name="org.jclouds" level="INFO" />


### PR DESCRIPTION
Support machines where multiple providers are installed.
Will pass the provider to use to vagrant, based on the selected image.

For example Fedora installs libvirt by default with virtualbox as an optional dependency.

The tests currently assume that the images `ubuntu/trusty64` and `ubuntu/xenial64` are already installed. These are `virtualbox` only images.
Still possible to test the libvirt integration by using another ubuntu image or `centos/7` (which does have libvirt variant) and run the tests with `mvn clean install -Plive -Dtest.vagrant.template=imageId=centos/7`.