### PR TITLE
Add Azure queue storage as new provider.

### DIFF
--- a/azure-queue-storage/README.txt
+++ b/azure-queue-storage/README.txt
@@ -1,0 +1,6 @@
+#
+# The jclouds provider for Windows Azure's Storage (http://www.microsoft.com/windowsazure/storage/default.aspx).
+#
+# TODO: Implementation status.
+# TODO: Supported features.
+# TODO: Usage example.

--- a/azure-queue-storage/pom.xml
+++ b/azure-queue-storage/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jclouds.labs</groupId>
+        <artifactId>jclouds-labs</artifactId>
+        <version>2.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>azure-queue-storage</artifactId>
+    <name>jclouds Azure Storage queue provider</name>
+    <description>jclouds components to access Azure queue storage Service</description>
+    <packaging>bundle</packaging>
+
+    <properties>
+    <test.azure-queue-storage.identity>FIXME_IDENTITY</test.azure-queue-storage.identity>
+    <test.azure-queue-storage.credential>FIXME_CREDENTIAL</test.azure-queue-storage.credential>
+
+    <jclouds.osgi.export>org.jclouds.azureblob*;version="${project.version}",org.jclouds.azure.storage*;version="${project.version}"</jclouds.osgi.export>
+        <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jclouds.driver</groupId>
+            <artifactId>jclouds-log4j</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>live</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>integration</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                <systemPropertyVariables>
+                                <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
+                                <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
+                                </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>
+

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageQueueApi.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageQueueApi.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jclouds.azure.storage;
+
+import org.jclouds.azure.storage.features.QueueApi;
+import org.jclouds.rest.annotations.Delegate;
+
+import java.io.Closeable;
+
+public interface AzureStorageQueueApi extends Closeable {
+
+   @Delegate
+   QueueApi getQueueApi();
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageQueueApiMetadata.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageQueueApiMetadata.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+import org.jclouds.apis.ApiMetadata;
+import org.jclouds.azure.storage.config.AzureStorageQueueModule;
+import org.jclouds.rest.internal.BaseHttpApiMetadata;
+
+import java.net.URI;
+import java.util.Properties;
+
+
+public class AzureStorageQueueApiMetadata extends BaseHttpApiMetadata {
+
+   @Override
+   public Builder toBuilder() {
+      return new Builder().fromApiMetadata(this);
+   }
+
+   public AzureStorageQueueApiMetadata() {
+      this(new Builder());
+   }
+
+   protected AzureStorageQueueApiMetadata(Builder builder) {
+      super(builder);
+   }
+
+   public static Properties defaultProperties() {
+      Properties properties = BaseHttpApiMetadata.defaultProperties();
+      properties.setProperty("x-ms-version", "2016-05-31");
+      return properties;
+   }
+
+   public static class Builder extends BaseHttpApiMetadata.Builder<AzureStorageQueueApi, Builder> {
+
+      protected Builder() {
+         super(AzureStorageQueueApi.class);
+         id("azure-queue-storage")
+                 .name("Azure Queue Storage")
+                 .identityName("Account")
+                 .credentialName("Key")
+                 .documentation(URI.create("https://docs.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api"))
+                 .defaultProperties(AzureStorageQueueApiMetadata.defaultProperties())
+                 .defaultEndpoint("https://${jclouds.identity}.queue.core.windows.net/")
+                 .defaultModules(ImmutableSet.<Class<? extends Module>>of(AzureStorageQueueModule.class))
+                 .version("2016-05-31");
+      }
+
+      @Override
+      public AzureStorageQueueApiMetadata build() {
+         return new AzureStorageQueueApiMetadata(this);
+      }
+
+      @Override
+      protected Builder self() {
+         return this;
+      }
+
+      @Override
+      public Builder fromApiMetadata(ApiMetadata in) {
+         return this;
+      }
+   }
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageQueueProviderMetadata.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageQueueProviderMetadata.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage;
+
+import com.google.auto.service.AutoService;
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+
+import java.util.Properties;
+
+@AutoService(ProviderMetadata.class)
+public final class AzureStorageQueueProviderMetadata extends BaseProviderMetadata {
+   @Override
+   public Builder toBuilder() {
+      return new Builder().fromProviderMetadata(this);
+   }
+
+   public AzureStorageQueueProviderMetadata() {
+      this(new Builder());
+   }
+
+   protected AzureStorageQueueProviderMetadata(Builder builder) {
+      super(builder);
+   }
+
+   public static Properties defaultProperties() {
+      Properties properties = AzureStorageQueueApiMetadata.defaultProperties();
+      return properties;
+   }
+
+   public static class Builder extends BaseProviderMetadata.Builder {
+
+      protected Builder() {
+         id("azure-queue-storage")
+                 .name("Azure Queue Storage")
+                 .apiMetadata(new AzureStorageQueueApiMetadata())
+                 .endpoint("https://${jclouds.identity}.queue.core.windows.net/")
+                 .defaultProperties(AzureStorageQueueProviderMetadata.defaultProperties());
+      }
+
+      @Override
+      public AzureStorageQueueProviderMetadata build() {
+         return new AzureStorageQueueProviderMetadata(this);
+      }
+
+      @Override
+      public Builder fromProviderMetadata(ProviderMetadata in) {
+         return this;
+      }
+   }
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageResponseException.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/AzureStorageResponseException.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage;
+
+import org.jclouds.azure.storage.domain.AzureQueueStorageError;
+import org.jclouds.http.HttpCommand;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.http.HttpResponseException;
+
+/**
+ * Encapsulates an Error from Azure Storage Services.
+ *
+ * @see <a href="http://docs.amazonwebservices.com/AmazonS3/2006-03-01/UsingRESTError.html" />
+ * @see AzureQueueStorageError
+ */
+public class AzureStorageResponseException extends HttpResponseException {
+
+   private AzureQueueStorageError error = new AzureQueueStorageError();
+
+   public AzureStorageResponseException(HttpCommand command, HttpResponse response, AzureQueueStorageError error) {
+      super(String.format("command %s failed with code %s, error: %s", command.toString(), response
+              .getStatusCode(), error.toString()), command, response);
+      this.setError(error);
+
+   }
+
+   public AzureStorageResponseException(HttpCommand command, HttpResponse response, AzureQueueStorageError error,
+                                        Throwable cause) {
+      super(String.format("command %1$s failed with error: %2$s", command.toString(), error
+              .toString()), command, response, cause);
+      this.setError(error);
+
+   }
+
+   public AzureStorageResponseException(String message, HttpCommand command, HttpResponse response,
+                                        AzureQueueStorageError error) {
+      super(message, command, response);
+      this.setError(error);
+
+   }
+
+   public AzureStorageResponseException(String message, HttpCommand command, HttpResponse response,
+                                        AzureQueueStorageError error, Throwable cause) {
+      super(message, command, response, cause);
+      this.setError(error);
+
+   }
+
+   public void setError(AzureQueueStorageError error) {
+      this.error = error;
+   }
+
+   public AzureQueueStorageError getError() {
+      return error;
+   }
+
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/config/AzureStorageQueueModule.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/config/AzureStorageQueueModule.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.config;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.inject.Provides;
+import org.jclouds.azure.storage.AzureStorageQueueApi;
+import org.jclouds.date.DateService;
+import org.jclouds.date.TimeStamp;
+import org.jclouds.json.config.GsonModule;
+import org.jclouds.rest.ConfiguresHttpApi;
+import org.jclouds.rest.config.HttpApiModule;
+
+import javax.inject.Named;
+import java.util.concurrent.TimeUnit;
+
+import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
+
+@ConfiguresHttpApi
+public class AzureStorageQueueModule extends HttpApiModule<AzureStorageQueueApi> {
+   @Override
+   protected void configure() {
+      super.configure();
+      bind(GsonModule.DateAdapter.class).to(GsonModule.Iso8601DateAdapter.class);
+   }
+
+   @Provides
+   @TimeStamp
+   protected final String guiceProvideTimeStamp(@TimeStamp Supplier<String> cache) {
+      return provideTimeStamp(cache);
+   }
+
+   protected String provideTimeStamp(@TimeStamp Supplier<String> cache) {
+      return cache.get();
+   }
+
+   /**
+    * borrowing concurrency code to ensure that caching takes place properly
+    */
+   @Provides
+   @TimeStamp
+   protected Supplier<String> provideTimeStampCache(@Named(PROPERTY_SESSION_INTERVAL) long seconds,
+                                                    final DateService dateService) {
+      return Suppliers.memoizeWithExpiration(new Supplier<String>() {
+         @Override
+         public String get() {
+            return dateService.rfc822DateFormat();
+         }
+      }, seconds, TimeUnit.SECONDS);
+   }
+
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/AzureQueueStorageError.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/AzureQueueStorageError.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.domain;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+/**
+ * When an Azure Storage request is in error, the client receives an error response.
+ *
+ * @see <a href="http://msdn.microsoft.com/en-us/library/dd573365.aspx" />
+ */
+public class AzureQueueStorageError {
+   private String code;
+   private String message;
+   private String requestId;
+   private Map<String, String> details = Maps.newHashMap();
+   private String stringSigned;
+   private String signature;
+
+   @Override
+   public String toString() {
+      final StringBuilder sb = new StringBuilder();
+      sb.append("AzureError");
+      sb.append("{requestId='").append(requestId).append('\'');
+      if (code != null)
+         sb.append(", code='").append(code).append('\'');
+      if (message != null)
+         sb.append(", message='").append(message).append('\'');
+      if (stringSigned != null)
+         sb.append(", stringSigned='").append(stringSigned).append('\'');
+      if (getSignature() != null)
+         sb.append(", signature='").append(getSignature()).append('\'');
+      if (!details.isEmpty())
+         sb.append(", context='").append(details.toString()).append('\'').append('}');
+      return sb.toString();
+   }
+
+   public void setCode(String code) {
+      this.code = code;
+   }
+
+   public String getCode() {
+      return code;
+   }
+
+   public void setMessage(String message) {
+      this.message = message;
+   }
+
+   public String getMessage() {
+      return message;
+   }
+
+   public void setRequestId(String requestId) {
+      this.requestId = requestId;
+   }
+
+   /**
+    * If a request is consistently failing and you have verified that the request is properly
+    * formulated, you may use this value to report the error to Microsoft. In your report, include
+    * the value of x-ms-request-id, the approximate time that the request was made, the storage
+    * service against which the request was made, and the type of operation that the request
+    * attempted
+    */
+   public String getRequestId() {
+      return requestId;
+   }
+
+   public void setStringSigned(String stringSigned) {
+      this.stringSigned = stringSigned;
+   }
+
+   /**
+    * @return what jclouds signed before sending the request.
+    */
+   public String getStringSigned() {
+      return stringSigned;
+   }
+
+   public void setDetails(Map<String, String> context) {
+      this.details = context;
+   }
+
+   /**
+    * @return additional details surrounding the error.
+    */
+   public Map<String, String> getDetails() {
+      return details;
+   }
+
+   public void setSignature(String signature) {
+      this.signature = signature;
+   }
+
+   public String getSignature() {
+      return signature;
+   }
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/internals/Queue.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/internals/Queue.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.domain.internals;
+
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Queue {
+   @XmlElement(name = "Name")
+   private String name;
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/internals/QueueMessage.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/internals/QueueMessage.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.domain.internals;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class QueueMessage {
+   @XmlElement(name = "MessageId")
+   private String messageId;
+
+   @XmlElement(name = "InsertionTime")
+   private String insertionTime;
+
+   @XmlElement(name = "ExpirationTime")
+   private String expirationTime;
+
+   @XmlElement(name = "PopReceipt")
+   private String popReceipt;
+
+   @XmlElement(name = "TimeNextVisible")
+   private String timeNextVisible;
+
+   @XmlElement(name = "DequeueCount")
+   private int dequeueCount;
+
+
+   @XmlElement(name = "MessageText")
+   private String messageText;
+
+
+   public String getMessageId() {
+      return messageId;
+   }
+
+   public void setMessageId(String messageId) {
+      this.messageId = messageId;
+   }
+
+   public String getInsertionTime() {
+      return insertionTime;
+   }
+
+   public void setInsertionTime(String insertionTime) {
+      this.insertionTime = insertionTime;
+   }
+
+   public String getExpirationTime() {
+      return expirationTime;
+   }
+
+   public void setExpirationTime(String expirationTime) {
+      this.expirationTime = expirationTime;
+   }
+
+   public String getPopReceipt() {
+      return popReceipt;
+   }
+
+   public void setPopReceipt(String popReceipt) {
+      this.popReceipt = popReceipt;
+   }
+
+   public String getTimeNextVisible() {
+      return timeNextVisible;
+   }
+
+   public void setTimeNextVisible(String timeNextVisible) {
+      this.timeNextVisible = timeNextVisible;
+   }
+
+   public int getDequeueCount() {
+      return dequeueCount;
+   }
+
+   public void setDequeueCount(int dequeueCount) {
+      this.dequeueCount = dequeueCount;
+   }
+
+   public String getMessageText() {
+      return messageText;
+   }
+
+   public void setMessageText(String messageText) {
+      this.messageText = messageText;
+   }
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/internals/QueueResponse/ListQueueResponse.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/domain/internals/QueueResponse/ListQueueResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.domain.internals.QueueResponse;
+
+import org.jclouds.azure.storage.domain.internals.Queue;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.List;
+
+@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+@XmlRootElement(name = "EnumerationResults")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ListQueueResponse {
+
+   @XmlElementWrapper(name = "Queues")
+   @XmlElement(name = "Queue")
+   private List<Queue> queues;
+
+   public List<Queue> getQueues() {
+      return queues;
+   }
+
+   public void setQueues(List<Queue> queues) {
+      this.queues = queues;
+   }
+
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/features/QueueApi.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/features/QueueApi.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.features;
+
+import org.jclouds.azure.storage.domain.internals.QueueResponse.ListQueueResponse;
+import org.jclouds.azure.storage.filters.SharedKeyLiteAuthentication;
+import org.jclouds.http.functions.ReturnTrueIf2xx;
+import org.jclouds.rest.annotations.Headers;
+import org.jclouds.rest.annotations.JAXBResponseParser;
+import org.jclouds.rest.annotations.QueryParams;
+import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.ResponseParser;
+
+import javax.inject.Named;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import java.io.Closeable;
+
+@Headers(keys = "x-ms-version", values = "{jclouds.api-version}")
+@RequestFilters(SharedKeyLiteAuthentication.class)
+public interface QueueApi extends Closeable {
+
+   @Named("azure_storage_queue_create")
+   @PUT
+   @Path("/{queueName}")
+   @ResponseParser(ReturnTrueIf2xx.class)
+   boolean create(@PathParam("queueName") String queueName);
+
+   @Named("azure_storage_queue_list")
+   @GET
+   @QueryParams(keys = "comp", values = "list")
+   @JAXBResponseParser
+   ListQueueResponse list();
+
+   @Named("azure_storage_queue_delete")
+   @DELETE
+   @Path("/{queueName}")
+   @ResponseParser(ReturnTrueIf2xx.class)
+   boolean delete(@PathParam("queueName") String queueName);
+
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/filters/SharedKeyLiteAuthentication.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/filters/SharedKeyLiteAuthentication.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.filters;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.io.ByteProcessor;
+import com.google.common.net.HttpHeaders;
+import org.jclouds.Constants;
+import org.jclouds.crypto.Crypto;
+import org.jclouds.date.TimeStamp;
+import org.jclouds.domain.Credentials;
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpRequestFilter;
+import org.jclouds.http.HttpUtils;
+import org.jclouds.http.internal.SignatureWire;
+import org.jclouds.logging.Logger;
+import org.jclouds.util.Strings2;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.google.common.io.BaseEncoding.base64;
+import static com.google.common.io.ByteStreams.readBytes;
+import static org.jclouds.crypto.Macs.asByteProcessor;
+import static org.jclouds.util.Patterns.NEWLINE_PATTERN;
+import static org.jclouds.util.Strings2.toInputStream;
+
+/**
+ * Signs the Azure Storage request.
+ *
+ * TODO Shoud move to common level package. see https://issues.apache.org/jira/browse/JCLOUDS-1324
+ * @see <a href= "http://msdn.microsoft.com/en-us/library/dd179428.aspx" />
+ */
+@Singleton
+public class SharedKeyLiteAuthentication implements HttpRequestFilter {
+   private static final Collection<String> FIRST_HEADERS_TO_SIGN = ImmutableList.of(HttpHeaders.DATE);
+
+   private final SignatureWire signatureWire;
+   private final Supplier<Credentials> creds;
+   private final Provider<String> timeStampProvider;
+   private final Crypto crypto;
+   private final HttpUtils utils;
+
+   @Resource
+   @Named(Constants.LOGGER_SIGNATURE)
+   Logger signatureLog = Logger.NULL;
+
+   @Inject
+   public SharedKeyLiteAuthentication(SignatureWire signatureWire,
+                                      @org.jclouds.location.Provider Supplier<Credentials> creds, @TimeStamp Provider<String> timeStampProvider,
+                                      Crypto crypto, HttpUtils utils) {
+      this.crypto = crypto;
+      this.utils = utils;
+      this.signatureWire = signatureWire;
+      this.creds = creds;
+      this.timeStampProvider = timeStampProvider;
+   }
+
+   public HttpRequest filter(HttpRequest request) throws HttpException {
+      request = replaceDateHeader(request);
+      String signature = calculateSignature(createStringToSign(request));
+      request = replaceAuthorizationHeader(request, signature);
+      utils.logRequest(signatureLog, request, "<<");
+      return request;
+   }
+
+   HttpRequest replaceAuthorizationHeader(HttpRequest request, String signature) {
+      return request.toBuilder()
+              .replaceHeader(HttpHeaders.AUTHORIZATION, "SharedKeyLite " + creds.get().identity + ":" + signature)
+              .build();
+   }
+
+   HttpRequest replaceDateHeader(HttpRequest request) {
+      Builder<String, String> builder = ImmutableMap.builder();
+      String date = timeStampProvider.get();
+      builder.put(HttpHeaders.DATE, date);
+      request = request.toBuilder().replaceHeaders(Multimaps.forMap(builder.build())).build();
+      return request;
+   }
+
+   public String createStringToSign(HttpRequest request) {
+      utils.logRequest(signatureLog, request, ">>");
+      StringBuilder buffer = new StringBuilder();
+      // re-sign the request
+      appendMethod(request, buffer);
+      appendPayloadMetadata(request, buffer);
+      appendHttpHeaders(request, buffer);
+      appendCanonicalizedHeaders(request, buffer);
+      appendCanonicalizedResource(request, buffer);
+      if (signatureWire.enabled())
+         signatureWire.output(buffer.toString());
+      return buffer.toString();
+   }
+
+   private void appendPayloadMetadata(HttpRequest request, StringBuilder buffer) {
+      buffer.append(
+              HttpUtils.nullToEmpty(request.getPayload() == null ? null : request.getPayload().getContentMetadata()
+                      .getContentMD5())).append("\n");
+      buffer.append(
+              Strings.nullToEmpty(request.getPayload() == null ? null : request.getPayload().getContentMetadata()
+                      .getContentType())).append("\n");
+   }
+
+   public String calculateSignature(String toSign) throws HttpException {
+      String signature = signString(toSign);
+      if (signatureWire.enabled())
+         signatureWire.input(Strings2.toInputStream(signature));
+      return signature;
+   }
+
+   public String signString(String toSign) {
+      try {
+         ByteProcessor<byte[]> hmacSHA256 = asByteProcessor(crypto.hmacSHA256(base64().decode(creds.get().credential)));
+         return base64().encode(readBytes(toInputStream(toSign), hmacSHA256));
+      } catch (Exception e) {
+         throw new HttpException("error signing request", e);
+      }
+   }
+
+   private void appendMethod(HttpRequest request, StringBuilder toSign) {
+      toSign.append(request.getMethod()).append("\n");
+   }
+
+   private void appendCanonicalizedHeaders(HttpRequest request, StringBuilder toSign) {
+      // TreeSet == Sort the headers alphabetically.
+      Set<String> headers = Sets.newTreeSet(request.getHeaders().keySet());
+      for (String header : headers) {
+         if (header.startsWith("x-ms-")) {
+            toSign.append(header.toLowerCase()).append(":");
+            for (String value : request.getHeaders().get(header)) {
+               toSign.append(NEWLINE_PATTERN.matcher(value).replaceAll("")).append(",");
+            }
+            toSign.deleteCharAt(toSign.lastIndexOf(","));
+            toSign.append("\n");
+         }
+      }
+   }
+
+   private void appendHttpHeaders(HttpRequest request, StringBuilder toSign) {
+      for (String header : FIRST_HEADERS_TO_SIGN)
+         toSign.append(HttpUtils.nullToEmpty(request.getHeaders().get(header))).append("\n");
+   }
+
+   @VisibleForTesting
+   void appendCanonicalizedResource(HttpRequest request, StringBuilder toSign) {
+      // 1. Beginning with an empty string (""), append a forward slash (/), followed by the name of
+      // the identity that owns the resource being accessed.
+      toSign.append("/").append(creds.get().identity);
+      appendUriPath(request, toSign);
+   }
+
+   @VisibleForTesting
+   void appendUriPath(HttpRequest request, StringBuilder toSign) {
+      // 2. Append the resource's encoded URI path
+      toSign.append(request.getEndpoint().getRawPath());
+
+      // If the request URI addresses a component of the
+      // resource, append the appropriate query string. The query string should include the question
+      // mark and the comp parameter (for example, ?comp=metadata). No other parameters should be
+      // included on the query string.
+      if (request.getEndpoint().getQuery() != null) {
+         StringBuilder paramsToSign = new StringBuilder("?");
+
+         String[] params = request.getEndpoint().getQuery().split("&");
+         for (String param : params) {
+            String[] paramNameAndValue = param.split("=");
+
+            if ("comp".equals(paramNameAndValue[0])) {
+               paramsToSign.append(param);
+            }
+         }
+
+         if (paramsToSign.length() > 1) {
+            toSign.append(paramsToSign);
+         }
+      }
+   }
+
+}

--- a/azure-queue-storage/src/main/java/org/jclouds/azure/storage/reference/AzureQueueStorageHeaders.java
+++ b/azure-queue-storage/src/main/java/org/jclouds/azure/storage/reference/AzureQueueStorageHeaders.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.reference;
+
+/**
+ * Additional headers specified by Azure Storage REST API.
+ *
+ * @see <a href="http://msdn.microsoft.com/en-us/library/dd179357.aspx" />
+ */
+public final class AzureQueueStorageHeaders {
+
+   public static final String REQUEST_ID = "x-ms-request-id";
+
+   private AzureQueueStorageHeaders() {
+      throw new AssertionError("intentionally unimplemented");
+   }
+}

--- a/azure-queue-storage/src/test/java/org/jclouds/azure/storage/AzureQueueProviderMetadataTest.java
+++ b/azure-queue-storage/src/test/java/org/jclouds/azure/storage/AzureQueueProviderMetadataTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage;
+
+import org.jclouds.providers.internal.BaseProviderMetadataTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "AzureQueueProviderMetadataTest")
+public final class AzureQueueProviderMetadataTest extends BaseProviderMetadataTest {
+   public AzureQueueProviderMetadataTest() {
+      super(new AzureStorageQueueProviderMetadata(), new AzureStorageQueueApiMetadata());
+   }
+}

--- a/azure-queue-storage/src/test/java/org/jclouds/azure/storage/features/AzureQueueApiLiveTest.java
+++ b/azure-queue-storage/src/test/java/org/jclouds/azure/storage/features/AzureQueueApiLiveTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.features;
+
+
+import org.jclouds.azure.storage.domain.internals.Queue;
+import org.jclouds.azure.storage.domain.internals.QueueResponse.ListQueueResponse;
+import org.jclouds.azure.storage.internal.BaseAzureQueueApiLiveTest;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class AzureQueueApiLiveTest extends BaseAzureQueueApiLiveTest{
+   private String queueName;
+
+   @Test(groups = "live")
+   public void testCreate() {
+      queueName = getQueueName();
+      QueueApi queueApi= api.getQueueApi();
+      boolean response = queueApi.create(queueName);
+      try{
+         assertThat(response).isEqualTo(true);
+      }
+      finally {
+         queueApi.delete(queueName);
+      }
+   }
+
+   @Test(groups = "live")
+   public void testDelete() {
+      queueName = getQueueName();
+      QueueApi queueApi= api.getQueueApi();
+      queueApi.create(queueName);
+      boolean response = queueApi.delete(queueName);
+      assertThat(response).isEqualTo(true);
+   }
+
+   @Test(groups = "live")
+   public void testList() {
+      queueName = getQueueName();
+      QueueApi queueApi= api.getQueueApi();
+      queueApi.create(queueName);
+      try {
+         boolean found = false;
+         ListQueueResponse queues = queueApi.list();
+         for (Queue queue : queues.getQueues()) {
+            if (queue.getName().equals(queueName)) {
+               found = true;
+            }
+         }
+         assertThat(found).isTrue();
+      } finally {
+         queueApi.delete(queueName);
+      }
+   }
+
+   private static String getQueueName() {
+      return "myqueue" + new Random().nextInt();
+   }
+}

--- a/azure-queue-storage/src/test/java/org/jclouds/azure/storage/features/AzureQueueApiMockTest.java
+++ b/azure-queue-storage/src/test/java/org/jclouds/azure/storage/features/AzureQueueApiMockTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.features;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import org.jclouds.azure.storage.domain.internals.QueueMessage;
+import org.jclouds.azure.storage.domain.internals.QueueResponse.ListQueueResponse;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jclouds.azure.storage.features.AzureQueueTestUtils.api;
+import static org.jclouds.azure.storage.features.AzureQueueTestUtils.createMockWebServer;
+import static org.jclouds.azure.storage.features.AzureQueueTestUtils.stringFromResource;
+
+
+@Test(groups = "unit", testName = "AzureQueueApiMockTest")
+public class AzureQueueApiMockTest {
+   private List<QueueMessage> response;
+
+   public void testCreate() throws Exception {
+      MockWebServer server = createMockWebServer();
+      server.enqueue(new MockResponse().setResponseCode(201));
+      try {
+         QueueApi api = api(server.getUrl("/").toString(), "azure-queue-storage").getQueueApi();
+         boolean response = api.create("1");
+         assertThat(response).isTrue();
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testDelete() throws Exception {
+      MockWebServer server = createMockWebServer();
+      server.enqueue(new MockResponse().setResponseCode(204));
+      try {
+         QueueApi api = api(server.getUrl("/").toString(), "azure-queue-storage").getQueueApi();
+         boolean response = api.delete("1");
+         assertThat(response).isTrue();
+      } finally {
+         server.shutdown();
+      }
+   }
+
+   public void testList() throws Exception {
+      MockWebServer server = createMockWebServer();
+      server.enqueue(new MockResponse().setBody(stringFromResource("/list_queue_response.xml")));
+
+      try {
+         QueueApi api = api(server.getUrl("/").toString(), "azure-queue-storage").getQueueApi();
+         ListQueueResponse response = api.list();
+
+         assertThat(response.getQueues().size()).isEqualTo(3);
+         assertThat(response.getQueues().get(0).getName()).isEqualTo("myqueue");
+      } finally {
+         server.shutdown();
+      }
+   }
+
+}

--- a/azure-queue-storage/src/test/java/org/jclouds/azure/storage/features/AzureQueueTestUtils.java
+++ b/azure-queue-storage/src/test/java/org/jclouds/azure/storage/features/AzureQueueTestUtils.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.features;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.inject.Module;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import org.jclouds.ContextBuilder;
+import org.jclouds.azure.storage.AzureStorageQueueApi;
+import org.jclouds.concurrent.config.ExecutorServiceModule;
+import org.jclouds.util.Strings2;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class AzureQueueTestUtils {
+   static AzureStorageQueueApi api(String uri, String provider, Properties overrides) {
+      Set<Module> modules = ImmutableSet.<Module> of(
+              new ExecutorServiceModule(MoreExecutors.sameThreadExecutor()));
+
+      return ContextBuilder.newBuilder(provider)
+              .credentials("ACCOUNT_ID", "APPLICATION_KEY")
+              .endpoint(uri)
+              .overrides(overrides)
+              .modules(modules)
+              .buildApi(AzureStorageQueueApi.class);
+   }
+
+   static AzureStorageQueueApi api(String uri, String provider) {
+      return api(uri, provider, new Properties());
+   }
+
+   static MockWebServer createMockWebServer() throws IOException {
+      MockWebServer server = new MockWebServer();
+      server.play();
+      URL url = server.getUrl("");
+      return server;
+   }
+
+   /**
+    * Ensures the request has a json header for the proper REST methods.
+    *
+    * @param request
+    * @param method
+    *           The request method (such as GET).
+    * @param path
+    *           The path requested for this REST call.
+    * @see RecordedRequest
+    */
+   static void assertRequest(RecordedRequest request, String method, String path) {
+      assertThat(request.getMethod()).isEqualTo(method);
+      assertThat(request.getPath()).isEqualTo(path);
+   }
+
+   /**
+    * Ensures the request is json and has the same contents as the resource
+    * file provided.
+    *
+    * @param request
+    * @param method
+    *           The request method (such as GET).
+    * @param resourceLocation
+    *           The location of the resource file. Contents will be compared to
+    *           the request body as JSON.
+    * @see RecordedRequest
+    */
+   static void assertRequest(RecordedRequest request, String method, String path, String resourceLocation) {
+      assertRequest(request, method, path);
+      assertContentTypeIsJson(request);
+      JsonParser parser = new JsonParser();
+      JsonElement requestJson;
+      try {
+         requestJson = parser.parse(new String(request.getBody(), Charsets.UTF_8));
+      } catch (Exception e) {
+         throw Throwables.propagate(e);
+      }
+      JsonElement resourceJson = parser.parse(stringFromResource(resourceLocation));
+      assertThat(requestJson).isEqualTo(resourceJson);
+   }
+
+   /**
+    * Ensures the request has a json header.
+    *
+    * @param request
+    * @see RecordedRequest
+    */
+   private static void assertContentTypeIsJson(RecordedRequest request) {
+      assertThat(request.getHeaders()).contains("Content-Type: application/json");
+   }
+
+   /**
+    * Get a string from a resource
+    *
+    * @param resourceName
+    *           The name of the resource.
+    * @return The content of the resource
+    */
+   static String stringFromResource(String resourceName) {
+      try {
+         return Strings2.toStringAndClose(AzureQueueApiMockTest.class.getResourceAsStream(resourceName));
+      } catch (IOException e) {
+         throw Throwables.propagate(e);
+      }
+   }
+}

--- a/azure-queue-storage/src/test/java/org/jclouds/azure/storage/internal/BaseAzureQueueApiLiveTest.java
+++ b/azure-queue-storage/src/test/java/org/jclouds/azure/storage/internal/BaseAzureQueueApiLiveTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azure.storage.internal;
+
+import org.jclouds.apis.ApiMetadata;
+import org.jclouds.apis.BaseApiLiveTest;
+import org.jclouds.azure.storage.AzureStorageQueueApi;
+import org.jclouds.azure.storage.AzureStorageQueueApiMetadata;
+
+public class BaseAzureQueueApiLiveTest extends BaseApiLiveTest<AzureStorageQueueApi>{
+
+   protected BaseAzureQueueApiLiveTest() {
+      provider = "azure-queue-storage";
+   }
+
+   static {
+      System.setProperty("azure-queue-storage.identity", "jcloudsazure");
+      System.setProperty("azure-queue-storage.credential", "nH+KqygOYN9cy6jcYwoqY4P77F62TWzP2c8ef+0AmespWPhK0UW/HoH8vsqhC44qLTdNgnKSqyVzbtBTaZXEpQ==");
+
+   }
+
+   @Override
+   protected ApiMetadata createApiMetadata() {
+      return new AzureStorageQueueApiMetadata();
+   }
+}

--- a/azure-queue-storage/src/test/resources/get_queue_response.xml
+++ b/azure-queue-storage/src/test/resources/get_queue_response.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<QueueMessagesList>
+    <QueueMessage>
+        <MessageId>0f79669d-e06c-4735-b61d-f7e65099d54c</MessageId>
+        <InsertionTime>Thu, 20 Jul 2017 06:17:12 GMT</InsertionTime>
+        <ExpirationTime>Thu, 27 Jul 2017 06:17:12 GMT</ExpirationTime>
+        <PopReceipt>AgAAAAMAAAAAAAAAUKlM7h8B0wE=</PopReceipt>
+        <TimeNextVisible>Thu, 20 Jul 2017 06:17:57 GMT</TimeNextVisible>
+        <MessageText>YXNkZmdoams=</MessageText>
+    </QueueMessage>
+    <QueueMessage>
+        <MessageId>0f79669d-e06c-4735-b61d-f7e65099d54c</MessageId>
+        <InsertionTime>Thu, 20 Jul 2017 06:17:12 GMT</InsertionTime>
+        <ExpirationTime>Thu, 27 Jul 2017 06:17:12 GMT</ExpirationTime>
+        <PopReceipt>AgAAAAMAAAAAAAAAUKlM7h8B0wE=</PopReceipt>
+        <TimeNextVisible>Thu, 20 Jul 2017 06:17:57 GMT</TimeNextVisible>
+        <MessageText>YXNkZmdoams=</MessageText>
+    </QueueMessage>
+</QueueMessagesList>

--- a/azure-queue-storage/src/test/resources/list_queue_response.xml
+++ b/azure-queue-storage/src/test/resources/list_queue_response.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EnumerationResults AccountName="https://jcloudsazure.queue.core.windows.net/">
+    <Queues>
+        <Queue>
+            <Name>myqueue</Name>
+            <Url>https://jcloudsazure.queue.core.windows.net/myqueue</Url>
+        </Queue>
+        <Queue>
+            <Name>myqueue1</Name>
+            <Url>https://jcloudsazure.queue.core.windows.net/myqueue1</Url>
+        </Queue>
+        <Queue>
+            <Name>myqueue2</Name>
+            <Url>https://jcloudsazure.queue.core.windows.net/myqueue2</Url>
+        </Queue>
+    </Queues>
+    <NextMarker />
+</EnumerationResults>

--- a/azure-queue-storage/src/test/resources/log4j.xml
+++ b/azure-queue-storage/src/test/resources/log4j.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!--
+    For more configuration infromation and examples see the Apache
+    Log4j website: http://logging.apache.org/log4j/
+-->
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/"
+                     debug="false">
+
+    <!-- A time/date based rolling appender -->
+    <appender name="WIREFILE" class="org.apache.log4j.DailyRollingFileAppender">
+        <param name="File" value="target/test-data/jclouds-wire.log" />
+        <param name="Append" value="true" />
+
+        <!-- Rollover at midnight each day -->
+        <param name="DatePattern" value="'.'yyyy-MM-dd" />
+
+        <param name="Threshold" value="TRACE" />
+
+        <layout class="org.apache.log4j.PatternLayout">
+            <!-- The default pattern: Date Priority [Category] Message\n -->
+            <param name="ConversionPattern" value="%d %-5p [%c] (%t) %m%n" />
+
+            <!--
+                The full pattern: Date MS Priority [Category]
+                (Thread:NDC) Message\n <param name="ConversionPattern"
+                value="%d %-5r %-5p [%c] (%t:%x) %m%n"/>
+            -->
+        </layout>
+    </appender>
+
+    <!-- A time/date based rolling appender -->
+    <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
+        <param name="File" value="target/test-data/jclouds.log" />
+        <param name="Append" value="true" />
+
+        <!-- Rollover at midnight each day -->
+        <param name="DatePattern" value="'.'yyyy-MM-dd" />
+
+        <param name="Threshold" value="TRACE" />
+
+        <layout class="org.apache.log4j.PatternLayout">
+            <!-- The default pattern: Date Priority [Category] Message\n -->
+            <param name="ConversionPattern" value="%d %-5p [%c] (%t) %m%n" />
+
+            <!--
+                The full pattern: Date MS Priority [Category]
+                (Thread:NDC) Message\n <param name="ConversionPattern"
+                value="%d %-5r %-5p [%c] (%t:%x) %m%n"/>
+            -->
+        </layout>
+    </appender>
+    <!-- A time/date based rolling appender -->
+    <appender name="BLOBSTOREFILE" class="org.apache.log4j.DailyRollingFileAppender">
+        <param name="File" value="target/test-data/jclouds-blobstore.log" />
+        <param name="Append" value="true" />
+        <param name="DatePattern" value="'.'yyyy-MM-dd" />
+        <param name="Threshold" value="TRACE" />
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d %-5p [%c] (%t) %m%n" />
+        </layout>
+    </appender>
+
+    <appender name="ASYNC" class="org.apache.log4j.AsyncAppender">
+        <appender-ref ref="FILE" />
+    </appender>
+
+    <appender name="ASYNCWIRE" class="org.apache.log4j.AsyncAppender">
+        <appender-ref ref="WIREFILE" />
+    </appender>
+
+    <appender name="ASYNCBLOBSTORE" class="org.apache.log4j.AsyncAppender">
+        <appender-ref ref="BLOBSTOREFILE" />
+    </appender>
+    <!-- ================ -->
+    <!-- Limit categories -->
+    <!-- ================ -->
+
+    <category name="org.jclouds">
+        <priority value="DEBUG" />
+        <appender-ref ref="ASYNC" />
+    </category>
+
+    <category name="jclouds.headers">
+        <priority value="DEBUG" />
+        <appender-ref ref="ASYNCWIRE" />
+    </category>
+    <!--
+        NOTE enabling this will break stream tests <category
+        name="jclouds.wire"> <priority value="DEBUG" /> <appender-ref
+        ref="ASYNCWIRE" /> </category>
+    -->
+    <category name="jclouds.blobstore">
+        <priority value="DEBUG" />
+        <appender-ref ref="ASYNCBLOBSTORE" />
+    </category>
+    <!-- ======================= -->
+    <!-- Setup the Root category -->
+    <!-- ======================= -->
+
+    <root>
+        <priority value="WARN" />
+    </root>
+
+</log4j:configuration>

--- a/azure-queue-storage/src/test/resources/post_queue_request.xml
+++ b/azure-queue-storage/src/test/resources/post_queue_request.xml
@@ -1,0 +1,3 @@
+<QueueMessage>
+    <MessageText>message-content</MessageText>
+</QueueMessage>

--- a/azure-queue-storage/src/test/resources/post_queue_response.xml
+++ b/azure-queue-storage/src/test/resources/post_queue_response.xml
@@ -1,0 +1,9 @@
+<QueueMessagesList>
+    <QueueMessage>
+        <MessageId>string-message-id</MessageId>
+        <InsertionTime>insertion-time</InsertionTime>
+        <ExpirationTime>expiration-time</ExpirationTime>
+        <PopReceipt>opaque-string-receipt-data</PopReceipt>
+        <TimeNextVisible>time-next-visible</TimeNextVisible>
+    </QueueMessage>
+</QueueMessagesList>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
   </repositories>
 
   <modules>
+    <module>azure-queue-storage</module>
     <module>azurecompute-arm</module>
     <module>azurecompute</module>
     <module>cdmi</module>


### PR DESCRIPTION
In this patch, we introduce azure queue storage as a new queue provider. 

Supported API:

- Queue Create
- Queue List
- Queue Delete
- Message Post
- Message Get (Batch)
- Message Delete

Doc: https://docs.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api